### PR TITLE
build on java8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 8
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 8
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
I would have preferred to continue building this on jdk11 and just get
an error for backwards incompatible api usage...
I tried various --release --source --target settings for both javac and scalac
options with no luck...