### PR TITLE
Safer NewDependency node creation

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -55,9 +55,9 @@ class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
 
   def createDependencyNode(name: String, groupId: String, version: String): NewDependency = {
     val dependency = NewDependency()
-      .version(version)
-      .name(name)
-      .dependencyGroupId(Some(groupId))
+      .name(Option(name).getOrElse("<n/a>"))
+      .dependencyGroupId(Option(groupId).getOrElse("<n/a>"))
+      .version(Option(version).getOrElse("<n/a>"))
       .build
     diffGraph.addNode(dependency)
     dependency


### PR DESCRIPTION
String values from the JS AST constructed by the graalvm js parser may be null for accessors like getName etc.

This is for: https://github.com/ShiftLeftSecurity/product/issues/8437

In the code of Homolog/payments-gateway-ms its a property node with a key without name which is apparently legal in JS. Hence, null there.