### PR TITLE
Fixed filenames for transpiling sub-projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ lazy val commonSettings = Seq(
     "org.slf4j"                % "slf4j-api"          % "1.7.32",
     "org.apache.logging.log4j" % "log4j-slf4j-impl"   % "2.14.1" % Runtime,
     "com.typesafe.play"        %% "play-json"         % "2.9.2",
+    "com.fasterxml.jackson"    % "jackson-base"       % "2.12.5",
     "com.atlassian.sourcemap"  % "sourcemap"          % "2.0.0",
     "commons-io"               % "commons-io"         % "2.11.0",
     "org.scalatest"            %% "scalatest"         % "3.2.9" % Test

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -103,8 +103,11 @@ class Js2Cpg {
 
     File.usingTemporaryDirectory("js2cpgTranspileOut") { tmpTranspileDir =>
       val jsFiles = findProjects(newTmpProjectDir, config)
-        .flatMap(new TranspilationRunner(_, tmpTranspileDir.path, config)
-          .execute())
+        .flatMap { p =>
+          val subDir =
+            if (p.toString != newTmpProjectDir.toString()) Some(project.relativize(p)) else None
+          new TranspilationRunner(p, tmpTranspileDir.path, config, subDir).execute()
+        }
         .distinctBy(_._1)
 
       FileUtils.logAndClearExcludedPaths()

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -106,7 +106,7 @@ class Js2Cpg {
         .flatMap { p =>
           val subDir =
             if (p.toString != newTmpProjectDir.toString()) Some(project.relativize(p)) else None
-          new TranspilationRunner(p, tmpTranspileDir.path, config, subDir).execute()
+          new TranspilationRunner(p, tmpTranspileDir.path, config, subDir = subDir).execute()
         }
         .distinctBy(_._1)
 

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -105,7 +105,8 @@ class Js2Cpg {
       val jsFiles = findProjects(newTmpProjectDir, config)
         .flatMap { p =>
           val subDir =
-            if (p.toString != newTmpProjectDir.toString()) Some(project.relativize(p)) else None
+            if (p.toString != newTmpProjectDir.toString()) Some(newTmpProjectDir.relativize(p))
+            else None
           new TranspilationRunner(p, tmpTranspileDir.path, config, subDir = subDir).execute()
         }
         .distinctBy(_._1)

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -51,7 +51,8 @@ object FileDefaults {
     ".*\\.tslint.*".r,
     ".*rollup\\.config.*".r,
     ".*\\.types\\.js".r,
-    ".*\\.cjs\\.js".r
+    ".*\\.cjs\\.js".r,
+    ".*js2cpgFakeTsFile.*".r // see: TypescriptTranspiler
   )
 
   val IGNORED_TESTS_REGEX: Seq[Regex] = List(

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -51,8 +51,7 @@ object FileDefaults {
     ".*\\.tslint.*".r,
     ".*rollup\\.config.*".r,
     ".*\\.types\\.js".r,
-    ".*\\.cjs\\.js".r,
-    ".*js2cpgFakeTsFile.*".r // see: TypescriptTranspiler
+    ".*\\.cjs\\.js".r
   )
 
   val IGNORED_TESTS_REGEX: Seq[Regex] = List(

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -49,6 +49,7 @@ object FileDefaults {
     ".*\\.babelrc.*".r,
     ".*\\.eslint.*".r,
     ".*\\.tslint.*".r,
+    ".*\\.stylelintrc\\.js".r,
     ".*rollup\\.config.*".r,
     ".*\\.types\\.js".r,
     ".*\\.cjs\\.js".r

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -11,7 +11,8 @@ import scala.util.{Failure, Success}
 
 class BabelTranspiler(override val config: Config,
                       override val projectPath: Path,
-                      subDir: Option[Path] = None)
+                      subDir: Option[Path] = None,
+                      inDir: Option[Path] = None)
     extends Transpiler
     with NpmEnvironment {
 
@@ -29,7 +30,11 @@ class BabelTranspiler(override val config: Config,
   }
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
-    val inDir = subDir.flatMap(dir => Some(projectPath.resolve(dir))).getOrElse(projectPath)
+    val in = inDir.map(dir => projectPath.resolve(dir)).getOrElse(projectPath)
+    val out =
+      subDir
+        .map(dir => Paths.get(tmpTranspileDir.toString, dir.toString))
+        .getOrElse(tmpTranspileDir)
     val babel = Paths.get(projectPath.toString, "node_modules", ".bin", "babel")
     val command = s"$babel . " +
       "--no-babelrc " +
@@ -43,9 +48,9 @@ class BabelTranspiler(override val config: Config,
       "--plugins @babel/plugin-proposal-object-rest-spread " +
       "--plugins @babel/plugin-proposal-nullish-coalescing-operator " +
       "--plugins @babel/plugin-transform-property-mutators " +
-      s"--out-dir $tmpTranspileDir $constructIgnoreDirArgs"
-    logger.debug(s"\t+ Babel transpiling $projectPath to $tmpTranspileDir")
-    ExternalCommand.run(command, inDir.toString) match {
+      s"--out-dir $out $constructIgnoreDirArgs"
+    logger.debug(s"\t+ Babel transpiling $projectPath to $out")
+    ExternalCommand.run(command, in.toString) match {
       case Success(result) =>
         logger.debug(s"\t+ Babel transpiling finished. $result")
       case Failure(exception) =>

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -31,10 +31,9 @@ class BabelTranspiler(override val config: Config,
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     val in = inDir.map(dir => projectPath.resolve(dir)).getOrElse(projectPath)
-    val out =
-      subDir
-        .map(dir => Paths.get(tmpTranspileDir.toString, dir.toString))
-        .getOrElse(tmpTranspileDir)
+    val outDir =
+      subDir.map(s => File(tmpTranspileDir.toString, s.toString)).getOrElse(File(tmpTranspileDir))
+
     val babel = Paths.get(projectPath.toString, "node_modules", ".bin", "babel")
     val command = s"$babel . " +
       "--no-babelrc " +
@@ -48,8 +47,8 @@ class BabelTranspiler(override val config: Config,
       "--plugins @babel/plugin-proposal-object-rest-spread " +
       "--plugins @babel/plugin-proposal-nullish-coalescing-operator " +
       "--plugins @babel/plugin-transform-property-mutators " +
-      s"--out-dir $out $constructIgnoreDirArgs"
-    logger.debug(s"\t+ Babel transpiling $projectPath to $out")
+      s"--out-dir $outDir $constructIgnoreDirArgs"
+    logger.debug(s"\t+ Babel transpiling $projectPath to $outDir")
     ExternalCommand.run(command, in.toString) match {
       case Success(result) =>
         logger.debug(s"\t+ Babel transpiling finished. $result")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -4,6 +4,7 @@ import better.files.File
 import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.io.FileDefaults.JS_SUFFIX
 import io.shiftleft.js2cpg.io.{ExternalCommand, FileUtils}
+import io.shiftleft.js2cpg.parser.PackageJsonParser
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}
@@ -43,6 +44,11 @@ class NuxtTranspiler(override val config: Config, override val projectPath: Path
   import NuxtTranspiler._
 
   private val logger = LoggerFactory.getLogger(getClass)
+
+  private def isNuxtProject: Boolean =
+    new PackageJsonParser((File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
+      .dependencies()
+      .contains("nuxt")
 
   override def shouldRun(): Boolean = config.nuxtTranspiling && isNuxtProject
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -53,7 +53,7 @@ class NuxtTranspiler(override val config: Config, override val projectPath: Path
     ExternalCommand.run(command, projectPath.toString) match {
       case Success(result) =>
         logger.debug(s"\t+ Nuxt.js transpiling finished. $result")
-        new BabelTranspiler(config, projectPath, Some(Paths.get(NUXT_FOLDER)))
+        new BabelTranspiler(config, projectPath, inDir = Some(Paths.get(NUXT_FOLDER)))
           .run(projectPath.resolve(NUXT_FOLDER))
         wasExecuted = true
       case Failure(exception) =>

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -24,7 +24,7 @@ class TranspilationRunner(projectPath: Path,
       projectPath,
       Seq(
         new NuxtTranspiler(config, projectPath),
-        new TypescriptTranspiler(config, projectPath, subDir),
+        new TypescriptTranspiler(config, projectPath, subDir = subDir),
         new BabelTranspiler(config, projectPath, subDir = subDir)
       )
     ),

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -11,18 +11,23 @@ import java.nio.file.{Path, StandardCopyOption}
 import scala.util.Try
 import scala.util.chaining.scalaUtilChainingOps
 
-class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Config) {
+class TranspilationRunner(projectPath: Path,
+                          tmpTranspileDir: Path,
+                          config: Config,
+                          subDir: Option[Path] = None) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   private val transpilers: Seq[Transpiler] = Seq(
-    new TranspilerGroup(config,
-                        projectPath,
-                        Seq(
-                          new NuxtTranspiler(config, projectPath),
-                          new TypescriptTranspiler(config, projectPath),
-                          new BabelTranspiler(config, projectPath)
-                        )),
+    new TranspilerGroup(
+      config,
+      projectPath,
+      Seq(
+        new NuxtTranspiler(config, projectPath),
+        new TypescriptTranspiler(config, projectPath, subDir),
+        new BabelTranspiler(config, projectPath, subDir = subDir)
+      )
+    ),
     new VueTranspiler(config, projectPath),
     new EjsTranspiler(config, projectPath),
     new PugTranspiler(config, projectPath),

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -47,11 +47,6 @@ trait Transpiler {
     hasVueDep || hasVueFiles
   }
 
-  protected def isNuxtProject: Boolean =
-    new PackageJsonParser((File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
-      .dependencies()
-      .contains("nuxt")
-
   def shouldRun(): Boolean
 
   def validEnvironment(): Boolean

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -8,9 +8,9 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import scala.util.{Failure, Success}
 
-class TranspilerGroup(override val config: Config,
-                      override val projectPath: Path,
-                      transpilers: Seq[Transpiler])
+case class TranspilerGroup(override val config: Config,
+                           override val projectPath: Path,
+                           transpilers: Seq[Transpiler])
     extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -84,12 +84,12 @@ class TypescriptTranspiler(override val config: Config,
           // that we sadly cannot override with tsc directly:
           val fakeTsConfigFile =
             File
-              .temporaryFile("js2cpgTsConfig", ".json", parent = Some(tmpTranspileDir))
+              .temporaryFile("js2cpgTsConfig", ".json", parent = Some(projectPath))
               .get()
               .createIfNotExists()
           // and a fake ts file to trick tsc. This gets around 'missing input files' error from tsc:
-          val fakeFile = File
-            .temporaryFile("js2cpgFakeTsFile", ".ts", parent = Some(tmpTranspileDir))
+          File
+            .temporaryFile("js2cpgFakeTsFile", ".ts", parent = Some(projectPath))
             .get()
             .createIfNotExists()
           val content =

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -96,8 +96,7 @@ class TypescriptTranspiler(override val config: Config,
             s"""
               |{
               | "compilerOptions": {},
-              | "include": ["**/*"],
-              | "exclude": ["$fakeFile"]
+              | "include": ["**/*"]
               |}
               |""".stripMargin
           fakeTsConfigFile.writeText(content)

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -39,10 +39,13 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         File.usingTemporaryDirectory() { transpileOutDir: File =>
           val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
-          val transpiledJsFiles =
-            new TranspilationRunner(tmpProjectPath.path,
-                                    transpileOutDir.path,
-                                    core.Config(tsTranspiling = false)).execute()
+          new TranspilationRunner(tmpProjectPath.path,
+                                  transpileOutDir.path,
+                                  core.Config(tsTranspiling = false)).execute()
+
+          val transpiledJsFiles = FileUtils
+            .getFileTree(transpileOutDir.path, core.Config(), JS_SUFFIX)
+            .map(f => (f, transpileOutDir.path))
 
           val expectedJsFiles = Set(((transpileOutDir / "foo.js").path, transpileOutDir.path))
           transpiledJsFiles should contain allElementsOf expectedJsFiles
@@ -93,10 +96,13 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
           jsFiles.size shouldBe 0
           tsFiles should contain allElementsOf expectedTsFiles
 
-          val transpiledJsFiles =
-            new TranspilationRunner(tmpProjectPath.path,
-                                    transpileOutDir.path,
-                                    core.Config(babelTranspiling = false)).execute()
+          new TranspilationRunner(tmpProjectPath.path,
+                                  transpileOutDir.path,
+                                  core.Config(babelTranspiling = false)).execute()
+
+          val transpiledJsFiles = FileUtils
+            .getFileTree(transpileOutDir.path, core.Config(), JS_SUFFIX)
+            .map(f => (f, transpileOutDir.path))
 
           val jsFilesAfterTranspilation = jsFiles ++ transpiledJsFiles
           jsFilesAfterTranspilation should contain allElementsOf expectedJsFiles


### PR DESCRIPTION
We have to consider:
The users may get confused once they start configuring a multi-module project with transpilation out dirs joined together or be dependent on each other. Our transpilation would yield different results than their config specifies.

_Its (virtual) sub-project (old behavior) vs. physical folder paths (new behavior with this PR)._

This is for: https://github.com/ShiftLeftSecurity/product/issues/8479