### PR TITLE
Added logging to file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val commonSettings = Seq(
     "org.graalvm.js"           % "js"                 % "21.1.0",
     "com.github.pathikrit"     %% "better-files"      % "3.9.1",
     "org.slf4j"                % "slf4j-api"          % "1.7.32",
-    "org.apache.logging.log4j" % "log4j-slf4j-impl"   % "2.14.1" % Runtime,
+    "org.apache.logging.log4j" % "log4j-slf4j-impl"   % "2.14.1",
     "com.typesafe.play"        %% "play-json"         % "2.9.2",
     "com.atlassian.sourcemap"  % "sourcemap"          % "2.0.0",
     "commons-io"               % "commons-io"         % "2.11.0",

--- a/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
@@ -31,6 +31,7 @@ object Config {
   val DEFAULT_INCLUDE_HTML: Boolean         = false
   val DEFAULT_JVM_METRICS: Option[Int]      = None
   val DEFAULT_MODULE_MODE: Option[String]   = None
+  val DEFAULT_LOG_FILE: Option[String]      = None
 
 }
 
@@ -52,6 +53,7 @@ case class Config(srcDir: String = "",
                   includeConfigs: Boolean = Config.DEFAULT_INCLUDE_CONFIGS,
                   includeHtml: Boolean = Config.DEFAULT_INCLUDE_HTML,
                   jvmMetrics: Option[Int] = Config.DEFAULT_JVM_METRICS,
+                  logFile: Option[String] = Config.DEFAULT_LOG_FILE,
                   moduleMode: Option[String] = Config.DEFAULT_MODULE_MODE) {
 
   def createPathForPackageJson(): Path = Paths.get(packageJsonLocation) match {

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
@@ -36,6 +36,7 @@ object Js2cpgArgumentsParser {
   val INCLUDE_CONFIGS: String      = "include-configs"
   val INCLUDE_HTML: String         = "include-html"
   val JVM_MONITOR: String          = "enable-jvm-monitor"
+  val LOG_FILE: String             = "log-file"
   val MODULE_MODE: String          = "module-mode"
 }
 
@@ -172,6 +173,9 @@ class Js2cpgArgumentsParser {
       .text(s"enable JVM metrics logging (requires JMX port number)")
       .action((jmxPortNumber, c) => c.copy(jvmMetrics = Some(jmxPortNumber)))
       .hidden()
+    opt[String](LOG_FILE)
+      .text(s"path to the log file (default is no log file)")
+      .action((logFile, c) => c.copy(logFile = Some(logFile)))
     opt[String](MODULE_MODE)
       .text(
         s"set the module mode for transpiling (default is ${TypescriptTranspiler.DEFAULT_MODULE}, alternatives are e.g., esnext or es2015)")


### PR DESCRIPTION
This PR adds a new file appender to our log4j config dynamically when js2cpg is called with `--log-file path/to/file`.
This requires to remove the `Runtime` flag at "org.apache.logging.log4j" % "log4j-slf4j-impl" in build.sbt as we need access to the actual logging implementation.

I do not really know if this breaks something @ release or in our CI/CD later on. Could we test this somehow?
Locally, everything is fine.

This is for: https://github.com/ShiftLeftSecurity/product/issues/8612