### PR TITLE
Added hash to CPG metadata

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -198,12 +198,13 @@ class Js2Cpg {
     val privateKeyFilePassPool = otherPools(3)
     val htmlAsConfigPassPool   = otherPools(4)
 
-    val cpg = newEmptyCpg(Some(config.outputFile))
+    val cpg  = newEmptyCpg(Some(config.outputFile))
+    val hash = FileUtils.md5(jsFilesWithRoot.map(_._1))
 
     new AstCreationPass(File(config.srcDir), jsFilesWithRoot, cpg, functionKeyPool, report)
       .createAndApply()
 
-    new JsMetaDataPass(cpg, metaDataKeyPool).createAndApply()
+    new JsMetaDataPass(cpg, metaDataKeyPool, hash).createAndApply()
     new BuiltinTypesPass(cpg, builtinTypesKeyPool).createAndApply()
     new DependenciesPass(cpg, config, dependenciesKeyPool)
       .createAndApply()

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.js2cpg.cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
+import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
 import org.slf4j.LoggerFactory
 
-class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool) extends CpgPass(cpg, keyPool = Some(keyPool)) {
+class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool, hash: String)
+    extends CpgPass(cpg, keyPool = Some(keyPool)) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -13,7 +15,7 @@ class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool) extends CpgPass(cpg, keyPool = 
     logger.debug(s"Generating meta-data.")
 
     val diffGraph = DiffGraph.newBuilder
-    val metaNode  = nodes.NewMetaData().language(Languages.JAVASCRIPT)
+    val metaNode  = NewMetaData().language(Languages.JAVASCRIPT).hash(hash)
     diffGraph.addNode(metaNode)
     Iterator(diffGraph.build())
   }

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPassTest.scala
@@ -13,7 +13,7 @@ class JsMetaDataPassTest extends AbstractPassTest {
     val cpg               = Cpg.emptyCpg
     val jsMetaDataKeyPool = new IntervalKeyPool(1, 100)
 
-    new JsMetaDataPass(cpg, jsMetaDataKeyPool).createAndApply()
+    new JsMetaDataPass(cpg, jsMetaDataKeyPool, "somehash").createAndApply()
 
     "create exactly 1 node" in {
       cpg.graph.V.asScala.size shouldBe 1
@@ -25,6 +25,10 @@ class JsMetaDataPassTest extends AbstractPassTest {
 
     "create a metadata node with correct language" in {
       cpg.metaData.language.l shouldBe List(Languages.JAVASCRIPT)
+    }
+
+    "create a metadata node with a hash" in {
+      cpg.metaData.hash.l shouldBe List("somehash")
     }
   }
 


### PR DESCRIPTION
The hash is calculated as a checksum of all *.js input files.
This is done after transpiling. Otherwise, it may happen, that we end up with
no files for the hash calculation at all (e.g., for TS projects).

Fixes: https://github.com/ShiftLeftSecurity/product/issues/8686