### PR TITLE
Added support for Swig templates

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/SwigTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/SwigTranspiler.scala
@@ -1,0 +1,86 @@
+package io.shiftleft.js2cpg.preprocessing
+
+import better.files.File
+import com.atlassian.sourcemap.WritableSourceMapImpl.Builder
+import io.shiftleft.js2cpg.core.Config
+import io.shiftleft.js2cpg.io.FileDefaults.HTML_SUFFIX
+import io.shiftleft.js2cpg.io.{ExternalCommand, FileDefaults, FileUtils}
+import org.slf4j.LoggerFactory
+
+import java.nio.file.{Path, Paths}
+import scala.util.{Failure, Success, Using}
+
+class SwigTranspiler(override val config: Config, override val projectPath: Path)
+    extends Transpiler
+    with NpmEnvironment {
+
+  private val SWIG_MARKERS = List("{%", "{{")
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val allSwigFiles: List[Path] = findSwigFiles()
+
+  private def findSwigFiles(): List[Path] =
+    FileUtils.getFileTree(projectPath, config, HTML_SUFFIX).filter { path =>
+      Using(FileUtils.bufferedSourceFromFile(path)) { bufferedSource =>
+        bufferedSource.getLines().exists(line => SWIG_MARKERS.exists(line.contains))
+      }.getOrElse(false)
+    }
+
+  private def hasSwigFiles: Boolean = allSwigFiles.nonEmpty
+
+  override def shouldRun(): Boolean = config.templateTranspiling && hasSwigFiles
+
+  private def installSwigPlugins(): Boolean = {
+    val command = if ((File(projectPath) / "yarn.lock").exists) {
+      s"yarn add swig --dev && ${NpmEnvironment.YARN_INSTALL}"
+    } else {
+      s"npm install --save-dev swig && ${NpmEnvironment.NPM_INSTALL}"
+    }
+    logger.debug(s"\t+ Installing Swig plugins ...")
+    ExternalCommand.run(command, projectPath.toString) match {
+      case Success(_) =>
+        logger.debug(s"\t+ Swig plugins installed")
+        true
+      case Failure(exception) =>
+        logger.debug(s"\t- Failed to install Swig plugins: ${exception.getMessage}")
+        false
+    }
+  }
+
+  override protected def transpile(tmpTranspileDir: Path): Boolean = {
+    if (installSwigPlugins()) {
+      val swig = Paths.get(projectPath.toString, "node_modules", ".bin", "swig")
+      allSwigFiles.foreach { swigFile =>
+        val outFile =
+          File(tmpTranspileDir.toString,
+               projectPath
+                 .relativize(swigFile)
+                 .toString
+                 .stripSuffix(FileDefaults.HTML_SUFFIX) + FileDefaults.JS_SUFFIX)
+        val command = s"$swig compile $swigFile"
+        logger.debug(s"\t+ transpiling Swig template $swigFile")
+        ExternalCommand.run(command, projectPath.toString) match {
+          case Success(result) =>
+            logger.debug(s"\t+ transpiling Swig template finished.")
+            outFile.createIfNotExists(createParents = true)
+            outFile.writeText(result)
+            val sourceMap =
+              new Builder()
+                .withSources(java.util.Collections.singletonList(swigFile.toString))
+                .build()
+            val sourceMapFile = File(outFile.parent, outFile.name + ".map")
+            sourceMapFile.writeText(sourceMap.generate())
+          case Failure(exception) =>
+            logger.debug(s"\t- transpiling Swig template failed: ${exception.getMessage}")
+        }
+      }
+    }
+    true
+  }
+
+  override def validEnvironment(): Boolean = valid()
+
+  override protected def logExecution(): Unit =
+    logger.info(s"Swig - transpiling source files in '${File(projectPath).name}'")
+}

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -36,7 +36,8 @@ class TranspilationRunner(projectPath: Path,
     if (subDir.isEmpty) {
       val otherTranspilers = Seq(new VueTranspiler(config, projectPath),
                                  new EjsTranspiler(config, projectPath),
-                                 new PugTranspiler(config, projectPath))
+                                 new PugTranspiler(config, projectPath),
+                                 new SwigTranspiler(config, projectPath))
       val base = baseTranspilers.copy(
         transpilers = baseTranspilers.transpilers.prepended(new NuxtTranspiler(config, projectPath))
       )

--- a/src/test/resources/swig/app/views/a.html
+++ b/src/test/resources/swig/app/views/a.html
@@ -1,0 +1,21 @@
+{% extends 'b.html' %}
+
+{% block title %}My Page{% endblock %}
+
+{% block head %}
+{% parent %}
+<link rel="stylesheet" href="custom.css">
+{% endblock %}
+
+{% block content %}
+<p>This is just an awesome page.</p>
+{% endblock %}
+
+{% if foo %}bar{% endif %}
+
+// Create a list of people, only if there are items in the people array
+{% for person in people %}
+{% if loop.first %}<ol>{% endif %}
+    <li>{{ person.name }}</li>
+    {% if loop.last %}</ol>{% endif %}
+{% endfor %}

--- a/src/test/resources/swig/app/views/b.html
+++ b/src/test/resources/swig/app/views/b.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}My Site{% endblock %}</title>
+
+    {% block head %}
+    <link rel="stylesheet" href="main.css">
+    {% endblock %}
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/src/test/resources/swig/package.json
+++ b/src/test/resources/swig/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "swig-test-project",
+  "version": "0.0.1",
+  "dependencies": {
+    "swig": "^1.4.2"
+  }
+}

--- a/src/test/resources/swig/static/index.html
+++ b/src/test/resources/swig/static/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- head definitions go here -->
+</head>
+<body>
+    <!-- the content goes here -->
+</body>
+</html>


### PR DESCRIPTION
The Swig cli tool does not support generating source-map files.
We have to live without re-mapped line/column numbers or reconstruct them by using
the HTML template files in a separate backend pass.

This is for: https://github.com/ShiftLeftSecurity/product/issues/8821