### PR TITLE
Updated dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val cpgVersion = "1.3.429"
+val cpgVersion = "1.3.431"
 
 val gitCommitString = SettingKey[String]("gitSha")
 
@@ -82,15 +82,15 @@ lazy val commonSettings = Seq(
     "io.shiftleft"             %% "codepropertygraph" % cpgVersion,
     "io.shiftleft"             %% "semanticcpg"       % cpgVersion,
     "com.github.scopt"         %% "scopt"             % "4.0.1",
-    "org.graalvm.js"           % "js"                 % "21.1.0",
+    "org.graalvm.js"           % "js"                 % "21.3.0",
     "com.github.pathikrit"     %% "better-files"      % "3.9.1",
     "org.slf4j"                % "slf4j-api"          % "1.7.32",
     "org.apache.logging.log4j" % "log4j-slf4j-impl"   % "2.14.1" % Runtime,
     "com.typesafe.play"        %% "play-json"         % "2.9.2",
-    "com.fasterxml.jackson"    % "jackson-base"       % "2.12.5",
+    "com.fasterxml.jackson"    % "jackson-base"       % "2.13.0",
     "com.atlassian.sourcemap"  % "sourcemap"          % "2.0.0",
     "commons-io"               % "commons-io"         % "2.11.0",
-    "org.scalatest"            %% "scalatest"         % "3.2.9" % Test
+    "org.scalatest"            %% "scalatest"         % "3.2.10" % Test
   ),
   Test / fork := true
 )

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -1719,19 +1719,15 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
 
   override def visit(templateLiteralNode: TemplateLiteralNode): NewNode = {
     val callId = astNodeBuilder.createCallNode(
-      templateLiteralNode.toString(),
+      s"__Runtime.TO_STRING(${templateLiteralNode.toString()})",
       s"__Runtime.TO_STRING",
       DispatchTypes.STATIC_DISPATCH,
       astNodeBuilder.lineAndColumn(templateLiteralNode)
     )
 
     val args = templateLiteralNode match {
-      case node: TemplateLiteralNode.TaggedTemplateLiteralNode =>
-        node.getRawStrings.asScala
-      case node: TemplateLiteralNode.UntaggedTemplateLiteralNode =>
-        node.getExpressions.asScala.zipWithIndex.collect {
-          case (expression, i) if i % 2 != 0 => expression
-        }
+      case node: TemplateLiteralNode.TaggedTemplateLiteralNode   => node.getRawStrings.asScala
+      case node: TemplateLiteralNode.UntaggedTemplateLiteralNode => node.getExpressions.asScala
     }
 
     args.foreach { expression =>

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -1730,10 +1730,10 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
       case node: TemplateLiteralNode.UntaggedTemplateLiteralNode => node.getExpressions.asScala
     }
 
+    val callOrder    = new OrderTracker()
+    val callArgIndex = new OrderTracker()
     args.foreach { expression =>
-      val callOrder    = new OrderTracker()
-      val callArgIndex = new OrderTracker()
-      val argId        = expression.accept(this)
+      val argId = expression.accept(this)
       astEdgeBuilder.addAstEdge(argId, callId, callOrder)
       astEdgeBuilder.addArgumentEdge(argId, callId, callArgIndex)
 

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -31,9 +31,9 @@ import com.oracle.js.parser.ir.{
   ParameterNode,
   PropertyNode,
   ReturnNode,
-  RuntimeNode,
   Statement,
   SwitchNode,
+  TemplateLiteralNode,
   TernaryNode,
   ThrowNode,
   TryNode,
@@ -44,7 +44,6 @@ import com.oracle.js.parser.ir.{
 }
 import com.oracle.js.parser.ir.LiteralNode.ArrayLiteralNode
 import io.shiftleft.codepropertygraph.generated.nodes.{
-  NewNode,
   NewBlock,
   NewCall,
   NewControlStructure,
@@ -53,6 +52,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethod,
   NewMethodRef,
   NewNamespaceBlock,
+  NewNode,
   NewTypeDecl,
   NewTypeRef
 }
@@ -64,17 +64,7 @@ import io.shiftleft.codepropertygraph.generated.{
 }
 import io.shiftleft.js2cpg.cpg.datastructures.Stack._
 import io.shiftleft.js2cpg.cpg.datastructures._
-import io.shiftleft.js2cpg.cpg.datastructures.scope.{
-  BlockScope,
-  BlockScopeElement,
-  MethodScope,
-  MethodScopeElement,
-  ResolvedReference,
-  Scope,
-  ScopeElement,
-  ScopeElementIterator,
-  ScopeType
-}
+import io.shiftleft.js2cpg.cpg.datastructures.scope._
 import io.shiftleft.js2cpg.cpg.passes.{Defines, EcmaBuiltins, PassHelpers}
 import io.shiftleft.js2cpg.cpg.passes.PassHelpers.ParamNodeInitKind
 import io.shiftleft.js2cpg.parser.{GeneralizingAstVisitor, JsSource}
@@ -1727,20 +1717,31 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
     }
   }
 
-  override def visit(runtimeNode: RuntimeNode): NewNode = {
-    val callId = astNodeBuilder.createCallNode(runtimeNode.toString(),
-                                               s"__Runtime.${runtimeNode.getRequest.toString}",
-                                               DispatchTypes.STATIC_DISPATCH,
-                                               astNodeBuilder.lineAndColumn(runtimeNode))
+  override def visit(templateLiteralNode: TemplateLiteralNode): NewNode = {
+    val callId = astNodeBuilder.createCallNode(
+      templateLiteralNode.toString(),
+      s"__Runtime.TO_STRING",
+      DispatchTypes.STATIC_DISPATCH,
+      astNodeBuilder.lineAndColumn(templateLiteralNode)
+    )
 
-    val callOrder    = new OrderTracker()
-    val callArgIndex = new OrderTracker()
-    runtimeNode.getArgs.forEach { arg =>
-      val argId = arg.accept(this)
-      astEdgeBuilder.addAstEdge(argId, callId, callOrder)
-      astEdgeBuilder.addArgumentEdge(argId, callId, callArgIndex)
+    val args = templateLiteralNode match {
+      case node: TemplateLiteralNode.TaggedTemplateLiteralNode =>
+        node.getRawStrings.asScala
+      case node: TemplateLiteralNode.UntaggedTemplateLiteralNode =>
+        node.getExpressions.asScala.zipWithIndex.collect {
+          case (expression, i) if i % 2 != 0 => expression
+        }
     }
 
+    args.foreach { expression =>
+      val callOrder    = new OrderTracker()
+      val callArgIndex = new OrderTracker()
+      val argId        = expression.accept(this)
+      astEdgeBuilder.addAstEdge(argId, callId, callOrder)
+      astEdgeBuilder.addArgumentEdge(argId, callId, callArgIndex)
+
+    }
     callId
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -1,34 +1,7 @@
 package io.shiftleft.js2cpg.cpg.passes.astcreation
 
 import com.oracle.js.parser.ir._
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  HasCode,
-  NewBinding,
-  NewBlock,
-  NewCall,
-  NewClosureBinding,
-  NewControlStructure,
-  NewDependency,
-  NewFieldIdentifier,
-  NewFile,
-  NewIdentifier,
-  NewJumpTarget,
-  NewLiteral,
-  NewLocal,
-  NewMember,
-  NewMethod,
-  NewMethodParameterIn,
-  NewMethodRef,
-  NewMethodReturn,
-  NewModifier,
-  NewNamespaceBlock,
-  NewNode,
-  NewReturn,
-  NewType,
-  NewTypeDecl,
-  NewTypeRef,
-  NewUnknown
-}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, Operators}
 import io.shiftleft.js2cpg.cpg.datastructures.{LineAndColumn, OrderTracker}
 import io.shiftleft.js2cpg.cpg.datastructures.scope.{MethodScope, Scope}

--- a/src/main/scala/io/shiftleft/js2cpg/parser/DefaultAstVisitor.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/DefaultAstVisitor.scala
@@ -204,11 +204,11 @@ abstract class DefaultAstVisitor(lexicalContext: LexicalContext = new LexicalCon
   override def leaveReturnNode(returnNode: ReturnNode): Node =
     super.leaveReturnNode(returnNode)
 
-  override def enterRuntimeNode(runtimeNode: RuntimeNode): Boolean =
-    super.enterRuntimeNode(runtimeNode)
+  override def enterTemplateLiteralNode(templateLiteralNode: TemplateLiteralNode): Boolean =
+    super.enterTemplateLiteralNode(templateLiteralNode)
 
-  override def leaveRuntimeNode(runtimeNode: RuntimeNode): Node =
-    super.leaveRuntimeNode(runtimeNode)
+  override def leaveTemplateLiteralNode(templateLiteralNode: TemplateLiteralNode): Node =
+    super.leaveTemplateLiteralNode(templateLiteralNode)
 
   override def enterSwitchNode(switchNode: SwitchNode): Boolean =
     super.enterSwitchNode(switchNode)

--- a/src/main/scala/io/shiftleft/js2cpg/parser/GeneralizingAstVisitor.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/GeneralizingAstVisitor.scala
@@ -233,7 +233,7 @@ class GeneralizingAstVisitor[T]
     visit(node.asInstanceOf[Statement])
   }
 
-  def visit(node: RuntimeNode): T = {
+  def visit(node: TemplateLiteralNode): T = {
     visit(node.asInstanceOf[Expression])
   }
 
@@ -417,7 +417,7 @@ class GeneralizingAstVisitor[T]
     visit(node)
   }
 
-  override def enterRuntimeNode(node: RuntimeNode): T = {
+  override def enterTemplateLiteralNode(node: TemplateLiteralNode): T = {
     visit(node)
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -13,13 +13,7 @@ import org.slf4j.LoggerFactory
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-object JsSource {
-  val tmpDir: String = System.getProperty("java.io.tmpdir")
-}
-
 class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
-
-  import JsSource.tmpDir
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
@@ -148,13 +148,12 @@ class AstCreationPassTest extends AbstractPassTest {
       def call = methodBlock.expandAst(NodeTypes.CALL)
       call.checkNodeCount(1)
       call.checkProperty(PropertyNames.NAME, "__Runtime.TO_STRING")
-      call.checkProperty(PropertyNames.CODE, s"__Runtime.TO_STRING(`$${x + 1}`)")
+      call.checkProperty(PropertyNames.CODE, "__Runtime.TO_STRING(x + 1)")
 
       def argument = call.expandAst(NodeTypes.CALL)
       argument.checkNodeCount(1)
-      // order 1 and 3 are " literals
-      argument.checkProperty(PropertyNames.ORDER, 2)
-      argument.checkProperty(PropertyNames.ARGUMENT_INDEX, 2)
+      argument.checkProperty(PropertyNames.ORDER, 1)
+      argument.checkProperty(PropertyNames.ARGUMENT_INDEX, 1)
       argument.checkProperty(PropertyNames.CODE, "x + 1")
     }
 
@@ -169,7 +168,7 @@ class AstCreationPassTest extends AbstractPassTest {
         def rawCall = methodBlock.expandAst(NodeTypes.CALL)
         rawCall.checkNodeCount(1)
         rawCall.checkProperty(PropertyNames.CODE,
-                              s"String.raw(__Runtime.TO_STRING(`../$${0}\\..`), 42)")
+                              """String.raw(__Runtime.TO_STRING("../","\.."), 42)""")
 
         def rawCallArg = rawCall.expandAst(NodeTypes.LITERAL)
         rawCallArg.checkNodeCount(1)
@@ -182,7 +181,7 @@ class AstCreationPassTest extends AbstractPassTest {
         runtimeCall.checkNodeCount(1)
         runtimeCall.checkProperty(PropertyNames.ORDER, 2)
         runtimeCall.checkProperty(PropertyNames.ARGUMENT_INDEX, 1)
-        runtimeCall.checkProperty(PropertyNames.CODE, s"__Runtime.TO_STRING(`../$${0}\\..`)")
+        runtimeCall.checkProperty(PropertyNames.CODE, """__Runtime.TO_STRING("../","\..")""")
 
         def argument1 =
           runtimeCall.expandAst(NodeTypes.LITERAL).filter(PropertyNames.CODE, "\"../\"")

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
@@ -152,6 +152,9 @@ class AstCreationPassTest extends AbstractPassTest {
 
       def argument = call.expandAst(NodeTypes.CALL)
       argument.checkNodeCount(1)
+      // order 1 and 3 are " literals
+      argument.checkProperty(PropertyNames.ORDER, 2)
+      argument.checkProperty(PropertyNames.ARGUMENT_INDEX, 2)
       argument.checkProperty(PropertyNames.CODE, "x + 1")
     }
 
@@ -170,20 +173,28 @@ class AstCreationPassTest extends AbstractPassTest {
 
         def rawCallArg = rawCall.expandAst(NodeTypes.LITERAL)
         rawCallArg.checkNodeCount(1)
+        rawCallArg.checkProperty(PropertyNames.ORDER, 3)
+        rawCallArg.checkProperty(PropertyNames.ARGUMENT_INDEX, 2)
         rawCallArg.checkProperty(PropertyNames.CODE, "42")
 
         def runtimeCall =
           rawCall.expandAst(NodeTypes.CALL).filter(PropertyNames.NAME, "__Runtime.TO_STRING")
         runtimeCall.checkNodeCount(1)
+        runtimeCall.checkProperty(PropertyNames.ORDER, 2)
+        runtimeCall.checkProperty(PropertyNames.ARGUMENT_INDEX, 1)
         runtimeCall.checkProperty(PropertyNames.CODE, s"__Runtime.TO_STRING(`../$${0}\\..`)")
 
         def argument1 =
           runtimeCall.expandAst(NodeTypes.LITERAL).filter(PropertyNames.CODE, "\"../\"")
         argument1.checkNodeCount(1)
+        argument1.checkProperty(PropertyNames.ORDER, 1)
+        argument1.checkProperty(PropertyNames.ARGUMENT_INDEX, 1)
 
         def argument2 =
           runtimeCall.expandAst(NodeTypes.LITERAL).filter(PropertyNames.CODE, "\"\\..\"")
         argument2.checkNodeCount(1)
+        argument2.checkProperty(PropertyNames.ORDER, 2)
+        argument2.checkProperty(PropertyNames.ARGUMENT_INDEX, 2)
     }
 
     "have correct structure for try" in AstFixture("""

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -69,18 +69,26 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
       }
     }
 
-    "have correct structure for runtime node" in {
+    "have correct structure for untagged runtime node" in {
       new CfgFixture(f"`$${x + 1}`") {
-        succOf(":program") shouldBe expected(("\"\"", AlwaysEdge))
-        succOf("\"\"") shouldBe expected(("x", AlwaysEdge))
+        succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("1", AlwaysEdge))
         succOf("1") shouldBe expected(("x + 1", AlwaysEdge))
-        succOf("x + 1") shouldBe expected(("Runtime.TO_STRING(x + 1)", AlwaysEdge))
-        succOf("Runtime.TO_STRING(x + 1)") shouldBe expected(
-          ("\"\" + Runtime.TO_STRING(x + 1)", AlwaysEdge))
-        succOf("\"\" + Runtime.TO_STRING(x + 1)") shouldBe expected(("\"\"", 1, AlwaysEdge))
-        succOf("\"\"", 1) shouldBe expected(("\"\" + Runtime.TO_STRING(x + 1) + \"\"", AlwaysEdge))
-        succOf("\"\" + Runtime.TO_STRING(x + 1) + \"\"") shouldBe expected(("RET", AlwaysEdge))
+        succOf("x + 1") shouldBe expected((f"`$${x + 1}`", AlwaysEdge))
+        succOf(f"`$${x + 1}`") shouldBe expected(("RET", AlwaysEdge))
+      }
+    }
+
+    "have correct structure for tagged runtime node" in {
+      new CfgFixture(f"String.raw`../${42}\\..`") {
+        succOf(":program") shouldBe expected(("String", AlwaysEdge))
+        succOf("String") shouldBe expected(("raw", AlwaysEdge))
+        succOf("raw") shouldBe expected(("String.raw", AlwaysEdge))
+        succOf("String.raw") shouldBe expected(("String", 1, AlwaysEdge))
+        succOf("String", 1) shouldBe expected(("\"../42\\..\"", AlwaysEdge))
+        succOf("\"../42\\..\"") shouldBe expected(("`../42\\..`", AlwaysEdge))
+        succOf("`../42\\..`") shouldBe expected(("String.raw(`../42\\..`)", AlwaysEdge))
+        succOf("String.raw(`../42\\..`)") shouldBe expected(("RET", AlwaysEdge))
       }
     }
 

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -71,13 +71,11 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
 
     "have correct structure for untagged runtime node" in {
       new CfgFixture(s"`$${x + 1}`") {
-        succOf(":program") shouldBe expected(("\"\"", AlwaysEdge))
-        succOf("\"\"") shouldBe expected(("x", AlwaysEdge))
+        succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("1", AlwaysEdge))
         succOf("1") shouldBe expected(("x + 1", AlwaysEdge))
-        succOf("x + 1") shouldBe expected(("\"\"", 1, AlwaysEdge))
-        succOf("\"\"", 1) shouldBe expected((s"__Runtime.TO_STRING(`$${x + 1}`)", AlwaysEdge))
-        succOf(s"__Runtime.TO_STRING(`$${x + 1}`)") shouldBe expected(("RET", AlwaysEdge))
+        succOf("x + 1") shouldBe expected(("__Runtime.TO_STRING(x + 1)", AlwaysEdge))
+        succOf("__Runtime.TO_STRING(x + 1)") shouldBe expected(("RET", AlwaysEdge))
       }
     }
 
@@ -89,11 +87,11 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf("String.raw") shouldBe expected(("String", 1, AlwaysEdge))
         succOf("String", 1) shouldBe expected(("\"../\"", AlwaysEdge))
         succOf("\"../\"") shouldBe expected(("\"\\..\"", AlwaysEdge))
-        succOf("\"\\..\"") shouldBe expected((s"__Runtime.TO_STRING(`../$${0}\\..`)", AlwaysEdge))
-        succOf(s"__Runtime.TO_STRING(`../$${0}\\..`)") shouldBe expected(("42", AlwaysEdge))
+        succOf("\"\\..\"") shouldBe expected(("__Runtime.TO_STRING(\"../\",\"\\..\")", AlwaysEdge))
+        succOf("__Runtime.TO_STRING(\"../\",\"\\..\")") shouldBe expected(("42", AlwaysEdge))
         succOf("42") shouldBe expected(
-          (s"String.raw(__Runtime.TO_STRING(`../$${0}\\..`), 42)", AlwaysEdge))
-        succOf(s"String.raw(__Runtime.TO_STRING(`../$${0}\\..`), 42)") shouldBe expected(
+          ("String.raw(__Runtime.TO_STRING(\"../\",\"\\..\"), 42)", AlwaysEdge))
+        succOf("String.raw(__Runtime.TO_STRING(\"../\",\"\\..\"), 42)") shouldBe expected(
           ("RET", AlwaysEdge))
       }
     }

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -70,25 +70,31 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
     }
 
     "have correct structure for untagged runtime node" in {
-      new CfgFixture(f"`$${x + 1}`") {
-        succOf(":program") shouldBe expected(("x", AlwaysEdge))
+      new CfgFixture(s"`$${x + 1}`") {
+        succOf(":program") shouldBe expected(("\"\"", AlwaysEdge))
+        succOf("\"\"") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("1", AlwaysEdge))
         succOf("1") shouldBe expected(("x + 1", AlwaysEdge))
-        succOf("x + 1") shouldBe expected((f"`$${x + 1}`", AlwaysEdge))
-        succOf(f"`$${x + 1}`") shouldBe expected(("RET", AlwaysEdge))
+        succOf("x + 1") shouldBe expected(("\"\"", 1, AlwaysEdge))
+        succOf("\"\"", 1) shouldBe expected((s"__Runtime.TO_STRING(`$${x + 1}`)", AlwaysEdge))
+        succOf(s"__Runtime.TO_STRING(`$${x + 1}`)") shouldBe expected(("RET", AlwaysEdge))
       }
     }
 
     "have correct structure for tagged runtime node" in {
-      new CfgFixture(f"String.raw`../${42}\\..`") {
+      new CfgFixture(s"String.raw`../$${42}\\..`") {
         succOf(":program") shouldBe expected(("String", AlwaysEdge))
         succOf("String") shouldBe expected(("raw", AlwaysEdge))
         succOf("raw") shouldBe expected(("String.raw", AlwaysEdge))
         succOf("String.raw") shouldBe expected(("String", 1, AlwaysEdge))
-        succOf("String", 1) shouldBe expected(("\"../42\\..\"", AlwaysEdge))
-        succOf("\"../42\\..\"") shouldBe expected(("`../42\\..`", AlwaysEdge))
-        succOf("`../42\\..`") shouldBe expected(("String.raw(`../42\\..`)", AlwaysEdge))
-        succOf("String.raw(`../42\\..`)") shouldBe expected(("RET", AlwaysEdge))
+        succOf("String", 1) shouldBe expected(("\"../\"", AlwaysEdge))
+        succOf("\"../\"") shouldBe expected(("\"\\..\"", AlwaysEdge))
+        succOf("\"\\..\"") shouldBe expected((s"__Runtime.TO_STRING(`../$${0}\\..`)", AlwaysEdge))
+        succOf(s"__Runtime.TO_STRING(`../$${0}\\..`)") shouldBe expected(("42", AlwaysEdge))
+        succOf("42") shouldBe expected(
+          (s"String.raw(__Runtime.TO_STRING(`../$${0}\\..`), 42)", AlwaysEdge))
+        succOf(s"String.raw(__Runtime.TO_STRING(`../$${0}\\..`), 42)") shouldBe expected(
+          ("RET", AlwaysEdge))
       }
     }
 


### PR DESCRIPTION
graalvm.js had a rather large change: https://github.com/oracle/graaljs/commit/0200ec151cced86cb6279c6da80b444d79bd0aef#diff-10e2be48c3df11d252a331de7fa8a5a51c2f7d7e602fe9540d58761566e30e22

The handling of runtime nodes was changed a lot. Let's see if this adaption works. Might break some sptests.