### PR TITLE
Set module mode to ESNEXT

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/TsConfigJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/TsConfigJsonParser.scala
@@ -19,7 +19,7 @@ object TsConfigJsonParser {
         val moduleOption = (json \ "compilerOptions" \ "module")
           .asOpt[String]
         moduleOption match {
-          case Some(module) if module == ESNEXT || module == ES2020 => ES2020
+          case Some(module) if module == ESNEXT || module == ES2020 => ESNEXT
           case _                                                    => DEFAULT_MODULE
         }
       case Failure(exception) =>


### PR DESCRIPTION
Was es2020 before. Looks like that one isn't actually available.