### PR TITLE
Added more ignored files for Webpack / Vue.js transpilation artifacts

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -44,7 +44,8 @@ object FileDefaults {
     ".*webpack\\..*\\.js".r,
     ".*vue\\.config\\.js".r,
     ".*babel\\.config\\.js".r,
-    ".*chunk-vendors\\.js".r,
+    ".*chunk-vendors.*\\.js".r, // commonly found in webpack / vue.js projects
+    ".*app~.*\\.js".r, // commonly found in webpack / vue.js projects
     ".*\\.chunk\\.js".r, // see: https://github.com/ShiftLeftSecurity/product/issues/8197
     ".*\\.babelrc.*".r,
     ".*\\.eslint.*".r,


### PR DESCRIPTION
This is for: https://github.com/ShiftLeftSecurity/product/issues/9339

Crashing constructs (strange CALLs) are from files not meant to be scanned in first place. 

