### PR TITLE
Added support for .mjs files

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -70,7 +70,7 @@ class Js2Cpg {
 
   private def findProjects(projectDir: File, config: Config): List[Path] = {
     val allProjects = FileUtils
-      .getFileTree(projectDir.path, config, ".json")
+      .getFileTree(projectDir.path, config, List(".json"))
       .filter(_.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME))
       .map(_.getParent)
 
@@ -97,7 +97,7 @@ class Js2Cpg {
                              dir: Path,
                              config: Config): List[(Path, Path)] = {
     val transpiledJsFiles = FileUtils
-      .getFileTree(dir, config, JS_SUFFIX)
+      .getFileTree(dir, config, List(JS_SUFFIX, MJS_SUFFIX))
       .map(f => (f, dir))
     jsFiles.filterNot {
       case (f, rootDir) =>
@@ -116,7 +116,7 @@ class Js2Cpg {
     FileUtils.logAndClearExcludedPaths()
 
     val jsFilesBeforeTranspiling = FileUtils
-      .getFileTree(newTmpProjectDir.path, config, JS_SUFFIX)
+      .getFileTree(newTmpProjectDir.path, config, List(JS_SUFFIX, MJS_SUFFIX))
       .map(f => (f, newTmpProjectDir.path))
 
     File.usingTemporaryDirectory("js2cpgTranspileOut") { tmpTranspileDir =>
@@ -180,11 +180,9 @@ class Js2Cpg {
   }
 
   private def configFiles(config: Config, extensions: List[String]): List[(Path, Path)] =
-    extensions.flatMap(
-      FileUtils
-        .getFileTree(File(config.srcDir).path, config, _, filterIgnoredFiles = false)
-        .map(f => (f, File(config.srcDir).path))
-    )
+    FileUtils
+      .getFileTree(File(config.srcDir).path, config, extensions, filterIgnoredFiles = false)
+      .map(f => (f, File(config.srcDir).path))
 
   private def generateCPG(config: Config, jsFilesWithRoot: List[(Path, Path)]): Unit = {
     val metaDataKeyPool     = new IntervalKeyPool(1, 100)

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
@@ -17,7 +17,7 @@ class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool)
 
     val packagesJsons =
       (FileUtils
-        .getFileTree(Paths.get(config.srcDir), config, ".json")
+        .getFileTree(Paths.get(config.srcDir), config, List(".json"))
         .filter(_.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME)) :+
         config.createPathForPackageJson()).toSet
 

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -12,6 +12,8 @@ object FileDefaults {
 
   val JS_SUFFIX: String = ".js"
 
+  val MJS_SUFFIX: String = ".mjs"
+
   val VUE_SUFFIX: String = ".vue"
 
   val HTML_SUFFIX: String = ".html"

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -108,7 +108,7 @@ object FileUtils {
   )(implicit
     copyOptions: File.CopyOptions = File.CopyOptions(false)): File = {
     val fileCollector = FileCollector(
-      PathFilter(from.path, config, filterIgnoredFiles = false, List.empty))
+      PathFilter(from.path, config, filterIgnoredFiles = false, extensions = List.empty))
     if (from.isDirectory) {
       Files.walkFileTree(
         from.path,

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -93,10 +93,9 @@ object FileUtils {
 
   def getFileTree(rootPath: Path,
                   config: Config,
-                  extension: String,
+                  extensions: List[String],
                   filterIgnoredFiles: Boolean = true): List[Path] = {
-    val fileCollector = FileCollector(
-      PathFilter(rootPath, config, filterIgnoredFiles, Some(extension)))
+    val fileCollector = FileCollector(PathFilter(rootPath, config, filterIgnoredFiles, extensions))
     Files.walkFileTree(rootPath, fileCollector)
     excludedPaths.addAll(fileCollector.excludedPaths)
     fileCollector.files
@@ -109,7 +108,7 @@ object FileUtils {
   )(implicit
     copyOptions: File.CopyOptions = File.CopyOptions(false)): File = {
     val fileCollector = FileCollector(
-      PathFilter(from.path, config, filterIgnoredFiles = false, None))
+      PathFilter(from.path, config, filterIgnoredFiles = false, List.empty))
     if (from.isDirectory) {
       Files.walkFileTree(
         from.path,

--- a/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
@@ -11,7 +11,7 @@ import scala.util.{Failure, Try}
 case class PathFilter(rootPath: Path,
                       config: Config,
                       filterIgnoredFiles: Boolean,
-                      extension: Option[String])
+                      extensions: List[String])
     extends (Path => FilterResult) {
 
   private val logger = LoggerFactory.getLogger(PathFilter.getClass)
@@ -39,11 +39,13 @@ case class PathFilter(rootPath: Path,
     * @param file the file to inspect
     * @return true iff file is a regular file and has the appropriate extension
     */
-  private def acceptFile(file: File): Boolean = extension match {
-    case Some(ext) =>
-      file.isRegularFile && !file.extension.contains(DTS_SUFFIX) && file.toString.endsWith(ext)
-    case None =>
+  private def acceptFile(file: File): Boolean = extensions match {
+    case Nil =>
       file.isRegularFile && !file.extension.contains(DTS_SUFFIX)
+    case exts =>
+      file.isRegularFile &&
+        !file.extension.contains(DTS_SUFFIX) &&
+        exts.exists(file.toString.endsWith)
   }
 
   private def filterFile(file: Path): FilterResult = {

--- a/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
@@ -40,9 +40,8 @@ case class PathFilter(rootPath: Path,
     * @return true iff file is a regular file and has the appropriate extension
     */
   private def acceptFile(file: File): Boolean =
-      file.isRegularFile && !file.extension.contains(DTS_SUFFIX) &&
-        (extensions.isEmpty || file.extension.exists(extensions.contains))
-  }
+    file.isRegularFile && !file.extension.contains(DTS_SUFFIX) &&
+      (extensions.isEmpty || file.extension.exists(extensions.contains))
 
   private def filterFile(file: Path): FilterResult = {
     val relFile = rootPath.relativize(file)

--- a/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
@@ -39,13 +39,9 @@ case class PathFilter(rootPath: Path,
     * @param file the file to inspect
     * @return true iff file is a regular file and has the appropriate extension
     */
-  private def acceptFile(file: File): Boolean = extensions match {
-    case Nil =>
-      file.isRegularFile && !file.extension.contains(DTS_SUFFIX)
-    case exts =>
-      file.isRegularFile &&
+  private def acceptFile(file: File): Boolean = file.isRegularFile &&
         !file.extension.contains(DTS_SUFFIX) &&
-        exts.exists(file.toString.endsWith)
+        (extensions.isEmpty || file.extension.exists(extensions.contains))
   }
 
   private def filterFile(file: Path): FilterResult = {

--- a/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
@@ -39,8 +39,8 @@ case class PathFilter(rootPath: Path,
     * @param file the file to inspect
     * @return true iff file is a regular file and has the appropriate extension
     */
-  private def acceptFile(file: File): Boolean = file.isRegularFile &&
-        !file.extension.contains(DTS_SUFFIX) &&
+  private def acceptFile(file: File): Boolean =
+      file.isRegularFile && !file.extension.contains(DTS_SUFFIX) &&
         (extensions.isEmpty || file.extension.exists(extensions.contains))
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/EjsTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/EjsTranspiler.scala
@@ -24,7 +24,7 @@ class EjsTranspiler(override val config: Config, override val projectPath: Path)
   private lazy val ejsFiles: List[Path] = allEjsFiles()
 
   private def allEjsFiles(): List[Path] =
-    FileUtils.getFileTree(projectPath, config, EJS_SUFFIX)
+    FileUtils.getFileTree(projectPath, config, List(EJS_SUFFIX))
 
   private def offset(str: String): Int =
     (str.trim.linesIterator.length - str.linesIterator.length) + 1

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -31,7 +31,7 @@ object NuxtTranspiler {
       FileUtils
         .getFileTree(nuxtFolder,
                      config.copy(ignoredFiles = config.ignoredFiles :+ nuxtDistFolder),
-                     JS_SUFFIX)
+                     List(JS_SUFFIX))
         .map(f => (f, dir))
     } else { Nil }
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -16,7 +16,7 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
   private val logger = LoggerFactory.getLogger(getClass)
 
   private def hasPugFiles: Boolean =
-    FileUtils.getFileTree(projectPath, config, PUG_SUFFIX).nonEmpty
+    FileUtils.getFileTree(projectPath, config, List(PUG_SUFFIX)).nonEmpty
 
   override def shouldRun(): Boolean = config.templateTranspiling && hasPugFiles
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -97,7 +97,7 @@ class TranspilationRunner(projectPath: Path,
         }
 
         FileUtils
-          .getFileTree(slPrivateDir.path, config, JS_SUFFIX)
+          .getFileTree(slPrivateDir.path, config, List(JS_SUFFIX, MJS_SUFFIX))
           .map(f => (f, slPrivateDir.path))
       } else List.empty
     }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -38,7 +38,7 @@ trait Transpiler {
   protected val projectPath: Path
 
   private def hasVueFiles: Boolean =
-    FileUtils.getFileTree(projectPath, config, VUE_SUFFIX).nonEmpty
+    FileUtils.getFileTree(projectPath, config, List(VUE_SUFFIX)).nonEmpty
 
   protected def isVueProject: Boolean = {
     val hasVueDep =

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -41,7 +41,7 @@ class TypescriptTranspiler(override val config: Config,
   private val tsc = Paths.get(projectPath.toString, "node_modules", ".bin", "tsc")
 
   private def hasTsFiles: Boolean =
-    FileUtils.getFileTree(projectPath, config, TS_SUFFIX).nonEmpty
+    FileUtils.getFileTree(projectPath, config, List(TS_SUFFIX)).nonEmpty
 
   override def shouldRun(): Boolean =
     config.tsTranspiling && (File(projectPath) / "tsconfig.json").exists && hasTsFiles && !isVueProject

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
@@ -2566,7 +2566,9 @@ class AstCreationPassTest extends AbstractPassTest {
     }
 
     "have correct name when using external source files" in AstFixture(
-      FileUtils.getFileTree(Paths.get("src/test/resources/closurebinding"), Config(), JS_SUFFIX)
+      FileUtils.getFileTree(Paths.get("src/test/resources/closurebinding"),
+                            Config(),
+                            List(JS_SUFFIX))
     ) { (file, cpg) =>
       def fileNode = cpg.file
       fileNode.checkNodeCount(1)

--- a/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
@@ -13,7 +13,7 @@ class FileUtilsTest extends AnyWordSpec with Matchers {
   "FileTree" should {
     "be correct for" in {
       FileUtils
-        .getFileTree(Paths.get("src/test/resources/hslnodejs"), Config(), JS_SUFFIX)
+        .getFileTree(Paths.get("src/test/resources/hslnodejs"), Config(), List(JS_SUFFIX))
         .size shouldBe 8
     }
 
@@ -28,7 +28,7 @@ class FileUtilsTest extends AnyWordSpec with Matchers {
         File.usingTemporaryDirectory() { targetDir: File =>
           val copiedDir = FileUtils.copyToDirectory(sourceDir, targetDir, Config())
 
-          val dirContent = FileUtils.getFileTree(copiedDir.path, Config(), JS_SUFFIX)
+          val dirContent = FileUtils.getFileTree(copiedDir.path, Config(), List(JS_SUFFIX))
 
           dirContent shouldBe empty
         }

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -44,7 +44,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
                                   core.Config(tsTranspiling = false)).execute()
 
           val transpiledJsFiles = FileUtils
-            .getFileTree(transpileOutDir.path, core.Config(), JS_SUFFIX)
+            .getFileTree(transpileOutDir.path, core.Config(), List(JS_SUFFIX))
             .map(f => (f, transpileOutDir.path))
 
           val expectedJsFiles = List(((transpileOutDir / "foo.js").path, transpileOutDir.path))
@@ -81,10 +81,10 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         File.usingTemporaryDirectory() { transpileOutDir: File =>
           val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
           val jsFiles = FileUtils
-            .getFileTree(tmpProjectPath.path, core.Config(), JS_SUFFIX)
+            .getFileTree(tmpProjectPath.path, core.Config(), List(JS_SUFFIX))
             .map(f => (f, tmpProjectPath.path))
           val tsFiles = FileUtils
-            .getFileTree(tmpProjectPath.path, core.Config(), TS_SUFFIX)
+            .getFileTree(tmpProjectPath.path, core.Config(), List(TS_SUFFIX))
             .map(f => (f, tmpProjectPath.path))
 
           val expectedTsFiles = List(((tmpProjectPath / "a.ts").path, tmpProjectPath.path),
@@ -100,7 +100,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
                                   core.Config(babelTranspiling = false)).execute()
 
           val transpiledJsFiles = FileUtils
-            .getFileTree(transpileOutDir.path, core.Config(), JS_SUFFIX)
+            .getFileTree(transpileOutDir.path, core.Config(), List(JS_SUFFIX))
             .map(f => (f, transpileOutDir.path))
 
           val jsFilesAfterTranspilation = jsFiles ++ transpiledJsFiles


### PR DESCRIPTION
.mjs an extension for EcmaScript modules.
It's a source code file containing an ES Module (ECMAScript Module) for use with a Node.js application.
These files are written in JavaScript, and may also use the .js extension outside the Node.js context.

We never added them beforehand, although they contain regular Javascript code.

_This may lead to more findings for customers._