### PR TITLE
Use yarn as default if available

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
@@ -22,7 +22,7 @@ class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool)
         config.createPathForPackageJson()).toSet
 
     val dependencies: Map[String, String] =
-      packagesJsons.flatMap(p => new PackageJsonParser(p).dependencies()).toMap
+      packagesJsons.flatMap(p => PackageJsonParser.dependencies(p)).toMap
 
     dependencies.foreach {
       case (name, version) =>

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -13,12 +13,12 @@ class BabelTranspiler(override val config: Config,
                       override val projectPath: Path,
                       subDir: Option[Path] = None,
                       inDir: Option[Path] = None)
-    extends Transpiler
-    with NpmEnvironment {
+    extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  override def shouldRun(): Boolean = config.babelTranspiling && !isVueProject
+  override def shouldRun(): Boolean =
+    config.babelTranspiling && !VueTranspiler.isVueProject(config, projectPath)
 
   private def constructIgnoreDirArgs: String = {
     val ignores = if (config.ignoreTests) {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -38,16 +38,15 @@ object NuxtTranspiler {
 }
 
 class NuxtTranspiler(override val config: Config, override val projectPath: Path)
-    extends Transpiler
-    with NpmEnvironment {
+    extends Transpiler {
 
   import NuxtTranspiler._
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   private def isNuxtProject: Boolean =
-    new PackageJsonParser((File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
-      .dependencies()
+    PackageJsonParser
+      .dependencies((File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
       .contains("nuxt")
 
   override def shouldRun(): Boolean = config.nuxtTranspiling && isNuxtProject

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -10,8 +10,7 @@ import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success}
 
 class PugTranspiler(override val config: Config, override val projectPath: Path)
-    extends Transpiler
-    with NpmEnvironment {
+    extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -21,10 +20,10 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
   override def shouldRun(): Boolean = config.templateTranspiling && hasPugFiles
 
   private def installPugPlugins(): Boolean = {
-    val command = if ((File(projectPath) / "yarn.lock").exists) {
-      s"yarn add pug-cli --dev && ${NpmEnvironment.YARN_INSTALL}"
+    val command = if (yarnAvailable()) {
+      s"yarn add pug-cli --dev && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"npm install --save-dev pug-cli && ${NpmEnvironment.NPM_INSTALL}"
+      s"npm install --save-dev pug-cli && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.debug(s"\t+ Installing Pug plugins ...")
     ExternalCommand.run(command, projectPath.toString) match {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -8,7 +8,7 @@ import io.shiftleft.js2cpg.parser.PackageJsonParser
 
 import java.nio.file.Path
 
-trait Transpiler {
+trait Transpiler extends TranspilingEnvironment {
 
   protected val DEFAULT_IGNORED_DIRS: List[String] = List(
     "build",
@@ -36,17 +36,6 @@ trait Transpiler {
 
   protected val config: Config
   protected val projectPath: Path
-
-  private def hasVueFiles: Boolean =
-    FileUtils.getFileTree(projectPath, config, List(VUE_SUFFIX)).nonEmpty
-
-  protected def isVueProject: Boolean = {
-    val hasVueDep =
-      new PackageJsonParser((File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
-        .dependencies()
-        .contains("vue")
-    hasVueDep || hasVueFiles
-  }
 
   def shouldRun(): Boolean
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -28,23 +28,11 @@ case class TranspilerGroup(override val config: Config,
       "@babel/plugin-proposal-nullish-coalescing-operator " +
       "@babel/plugin-transform-property-mutators"
 
-  private def isYarnAvailable: Boolean = {
-    logger.debug("\t+ Checking yarn ...")
-    ExternalCommand.run("yarn -v", projectPath.toString) match {
-      case Success(result) =>
-        logger.debug(s"\t+ yarn is available: $result")
-        true
-      case Failure(_) =>
-        logger.error("\t- yarn is not installed. Transpiling sources will not be available.")
-        false
-    }
-  }
-
   private def installPlugins(): Boolean = {
-    val command = if ((File(projectPath) / "yarn.lock").exists && isYarnAvailable) {
-      s"yarn add $BABEL_PLUGINS --dev -W && ${NpmEnvironment.YARN_INSTALL}"
+    val command = if (yarnAvailable()) {
+      s"yarn add $BABEL_PLUGINS --dev -W && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"npm install --save-dev $BABEL_PLUGINS && ${NpmEnvironment.NPM_INSTALL}"
+      s"npm install --save-dev $BABEL_PLUGINS && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.info("Installing project dependencies and plugins. This might take a while.")
     logger.debug("\t+ Installing plugins ...")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -31,8 +31,7 @@ object TypescriptTranspiler {
 class TypescriptTranspiler(override val config: Config,
                            override val projectPath: Path,
                            subDir: Option[Path] = None)
-    extends Transpiler
-    with NpmEnvironment {
+    extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -44,7 +43,10 @@ class TypescriptTranspiler(override val config: Config,
     FileUtils.getFileTree(projectPath, config, List(TS_SUFFIX)).nonEmpty
 
   override def shouldRun(): Boolean =
-    config.tsTranspiling && (File(projectPath) / "tsconfig.json").exists && hasTsFiles && !isVueProject
+    config.tsTranspiling &&
+      (File(projectPath) / "tsconfig.json").exists &&
+      hasTsFiles &&
+      !VueTranspiler.isVueProject(config, projectPath)
 
   private def moveIgnoredDirs(from: File, to: File): Unit = {
     val ignores = if (config.ignoreTests) {

--- a/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
@@ -26,10 +26,8 @@ class FileUtilsTest extends AnyWordSpec with Matchers {
         (sourceDir / ".folder" / "e.js").createIfNotExists(createParents = true)
 
         File.usingTemporaryDirectory() { targetDir: File =>
-          val copiedDir = FileUtils.copyToDirectory(sourceDir, targetDir, Config())
-
+          val copiedDir  = FileUtils.copyToDirectory(sourceDir, targetDir, Config())
           val dirContent = FileUtils.getFileTree(copiedDir.path, Config(), List(JS_SUFFIX))
-
           dirContent shouldBe empty
         }
       }

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -83,12 +83,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
           val jsFiles = FileUtils
             .getFileTree(tmpProjectPath.path, core.Config(), List(JS_SUFFIX))
             .map(f => (f, tmpProjectPath.path))
-          val tsFiles = FileUtils
-            .getFileTree(tmpProjectPath.path, core.Config(), List(TS_SUFFIX))
-            .map(f => (f, tmpProjectPath.path))
 
-          val expectedTsFiles = List(((tmpProjectPath / "a.ts").path, tmpProjectPath.path),
-                                     ((tmpProjectPath / "b.ts").path, tmpProjectPath.path))
           val expectedJsFiles =
             List(((transpileOutDir / "a.js").path, transpileOutDir.path),
                  ((transpileOutDir / "b.js").path, transpileOutDir.path))


### PR DESCRIPTION
Yarn has a much better performance (especially under Windows) compared to the plain old npm (50% speedup on my machine).
We use this as default now if available.

Also:
  * applied caching to PackageJsonParser
  * refactored TranspilingEnvironment