### PR TITLE
Fix for failing installation of peer dependencies via npm/yarn

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -30,12 +30,12 @@ case class TranspilerGroup(override val config: Config,
 
   private def installPlugins(): Boolean = {
     val command = if (yarnAvailable()) {
-      s"yarn add $BABEL_PLUGINS --dev -W && ${TranspilingEnvironment.YARN_INSTALL}"
+      s"yarn add $BABEL_PLUGINS --dev -W --legacy-peer-deps && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"npm install --save-dev $BABEL_PLUGINS && ${TranspilingEnvironment.NPM_INSTALL}"
+      s"npm install --save-dev $BABEL_PLUGINS --legacy-peer-deps && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.info("Installing project dependencies and plugins. This might take a while.")
-    logger.debug("\t+ Installing plugins ...")
+    logger.debug(s"\t+ Installing plugins with command '$command' in path '$projectPath'")
     ExternalCommand.run(command, projectPath.toString) match {
       case Success(_) =>
         logger.debug("\t+ Plugins installed")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -34,14 +34,14 @@ case class TranspilerGroup(override val config: Config,
     } else {
       s"npm install --save-dev $BABEL_PLUGINS --legacy-peer-deps && ${TranspilingEnvironment.NPM_INSTALL}"
     }
-    logger.info("Installing project dependencies and plugins. This might take a while.")
+    logger.info("Installing project dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing plugins with command '$command' in path '$projectPath'")
     ExternalCommand.run(command, projectPath.toString) match {
       case Success(_) =>
-        logger.debug("\t+ Plugins installed")
+        logger.info("\t+ Plugins installed")
         true
       case Failure(exception) =>
-        logger.debug(s"\t- Failed to install plugins: ${exception.getMessage}")
+        logger.error(s"\t- Failed to install plugins: ${exception.getMessage}")
         false
     }
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -13,8 +13,8 @@ object TranspilingEnvironment {
   private var isYarnAvailable: Option[Boolean] = None
   private var isNpmAvailable: Option[Boolean]  = None
 
-  val YARN_INSTALL = "yarn install --prefer-offline --ignore-scripts"
-  val NPM_INSTALL  = "npm install --prefer-offline --no-audit --progress=false --ignore-scripts"
+  val YARN_INSTALL = "yarn install --prefer-offline --ignore-scripts --legacy-peer-deps"
+  val NPM_INSTALL  = "npm install --prefer-offline --no-audit --progress=false --ignore-scripts --legacy-peer-deps"
 }
 
 trait TranspilingEnvironment {


### PR DESCRIPTION
We see failing npm/yarn install, e.g., for the latest master version of juice-shop due to broken dependencies via its package.json.

--legacy-peer-deps parameter fixes that to a certain extend. See: https://stackoverflow.com/a/66608842