### PR TITLE
upgrade release plugin, which brings in latest sbt-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,7 @@ lazy val js2cpg = (project in file(".")).settings(
     "-Dlog4j.configurationFile=file:src/test/resources/log4j2-test.xml"
   ),
   publishTo := sonatypePublishToBundle.value,
+  sonatypeTimeoutMillis := 7200000,
   scmInfo := Some(
     ScmInfo(url("https://github.com/ShiftLeftSecurity/js2cpg"),
             "scm:git@github.com:ShiftLeftSecurity/js2cpg.git")),

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val joernVersion = "1.1.387"
 
 val gitCommitString = SettingKey[String]("gitSha")
 
-enablePlugins(JavaAppPackaging, GitVersioning, BuildInfoPlugin)
+enablePlugins(JavaAppPackaging, BuildInfoPlugin)
 
 lazy val Fast = config("fast").extend(Test)
 configs(Fast)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager"  % "1.3.5")
 addSbtPlugin("com.geirsson"     % "sbt-scalafmt"         % "1.5.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"              % "1.0.0")
-addSbtPlugin("io.shiftleft"     % "sbt-ci-release-early" % "1.2.2")
+addSbtPlugin("io.shiftleft"     % "sbt-ci-release-early" % "2.0.18")
+addSbtPlugin("com.dwijnand"     % "sbt-dynver"           % "4.1.1")
 addSbtPlugin("com.eed3si9n"     % "sbt-assembly"         % "0.14.5")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"        % "0.8.0")


### PR DESCRIPTION
which has configurable timeouts, which may help us fix the release
issues