### PR TITLE
Fixed potential null pointer when iterating source map content

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/EmScriptenCleaner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/EmScriptenCleaner.scala
@@ -8,15 +8,15 @@ object EmScriptenCleaner {
     * If code contains emscripten code (marked with start funcs and end funcs comments)
     * we simply replace it with empty lines.
     */
-  def clean(code: Seq[String]): Iterator[String] = {
+  def clean(code: Seq[String]): Seq[String] = {
     val startIndex = code.indexWhere(EMSCRIPTEN_START_FUNCS.matches)
     val endIndex   = code.indexWhere(EMSCRIPTEN_END_FUNCS.matches)
     if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
-      (code.slice(0, startIndex) ++
+      code.slice(0, startIndex) ++
         Seq.fill(endIndex - startIndex - 1)(System.lineSeparator()) ++
-        code.slice(endIndex + 1, code.length)).iterator
+        code.slice(endIndex + 1, code.length)
     } else {
-      code.iterator
+      code
     }
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -124,7 +124,7 @@ object FileUtils {
   }
 
   def readLinesInFile(path: Path): Seq[String] =
-    EmScriptenCleaner.clean(IOUtils.readLinesInFile(path)).toSeq
+    EmScriptenCleaner.clean(IOUtils.readLinesInFile(path))
 
   def contentMapFromFile(path: Path): Map[Int, String] =
     readLinesInFile(path).zipWithIndex.map {

--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -112,7 +112,7 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
     } else {
       val sourceMapContent = FileUtils.readLinesInFile(Paths.get(mapFilePath)).mkString("\n")
       val sourceMap        = ReadableSourceMapImpl.fromSource(sourceMapContent)
-      val sourceFileNames  = sourceMap.getSources.asScala
+      val sourceFileNames  = sourceMap.getSources.asScala.filter(_ != null)
 
       // The source file might not exist, e.g., if it was the result of transpilation
       // but is not delivered and still referenced in the source map

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -17,9 +17,9 @@ object TranspilingEnvironment {
   val NPM: String  = ExternalCommand.toOSCommand("npm")
 
   val YARN_ADD: String =
-    s"$YARN} add --prefer-offline --ignore-scripts --legacy-peer-deps"
+    s"$YARN add --prefer-offline --ignore-scripts --legacy-peer-deps"
   val YARN_INSTALL: String =
-    s"$YARN} install --prefer-offline --ignore-scripts --legacy-peer-deps"
+    s"$YARN install --prefer-offline --ignore-scripts --legacy-peer-deps"
   val NPM_INSTALL: String =
     s"$NPM install --prefer-offline --no-audit --progress=false --ignore-scripts --legacy-peer-deps"
 }


### PR DESCRIPTION
This happened in one of the gazelle js test projects.

Also:
 * fixed yarn command (dangling `}`)
 * removed unnecessary iterator <-> seq conversion