### PR TITLE
Removed Nul characters during source map path construction

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -52,7 +52,12 @@ object FileUtils {
     * occur during transpilation on the Windows platform and/or CI environments.
     */
   def cleanPath(sourceFileName: String): String = {
-    val replacedDots = sourceFileName.replace("../", "")
+    val replacedDots = sourceFileName.
+    // replace leading relative path elements
+    replace("../", "").
+    // replace Nul characters (happens in some internationalized source maps)
+    replace("\u0000", "")
+
     val replacedFile = if ("""file:///.:.*""".r.matches(replacedDots)) {
       replacedDots.replace("file:///", "")
     } else {


### PR DESCRIPTION
Nul characters in paths may be present in some internationalized source maps.
This happens e.g., in the npm package `intl` and would crash js2cpg if not removed.