### PR TITLE
Fixed parsing of invalid source maps

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -11,6 +11,7 @@ import io.shiftleft.js2cpg.preprocessing.NuxtTranspiler
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
 
 class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
 
@@ -106,35 +107,40 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
   }
 
   private def sourceMapOrigin(): Option[SourceMapOrigin] = {
-    if (File(mapFilePath).notExists) {
+    if (File(mapFilePath).isEmpty) {
       logger.debug(s"No source map file available for '$originalFilePath'")
       None
     } else {
       val sourceMapContent = FileUtils.readLinesInFile(Paths.get(mapFilePath)).mkString("\n")
-      val sourceMap        = ReadableSourceMapImpl.fromSource(sourceMapContent)
-      val sourceFileNames  = sourceMap.getSources.asScala.filter(_ != null)
-
-      // The source file might not exist, e.g., if it was the result of transpilation
-      // but is not delivered and still referenced in the source map
-      // (fix for: https://github.com/ShiftLeftSecurity/product/issues/4994)
-      val sourceFile = sourceFileNames
-        .find(_.toLowerCase.endsWith(File(absoluteFilePath).nameWithoutExtension + VUE_SUFFIX))
-        .orElse(sourceFileNames.headOption)
-
-      sourceFile.flatMap { sourceFileName =>
-        val sourceFilePath = constructSourceFilePath(sourceFileName)
-        if (!sourceFilePath.exists) {
-          logger.debug(
-            s"Could not load source map file for '$originalFilePath'. The source map file refers to '$sourceFilePath' but this does not exist")
+      // We apply a Try here as some source maps are indeed un-parsable by ReadableSourceMap:
+      Try(ReadableSourceMapImpl.fromSource(sourceMapContent)) match {
+        case Failure(exception) =>
+          logger.debug(s"Invalid source map file for '$originalFilePath'", exception)
           None
-        } else {
-          val sourceFileMapping = FileUtils.contentMapFromFile(Paths.get(mapFilePath))
-          logger.debug(
-            s"Successfully loaded source map file '$mapFilePath':" +
-              s"\n\t* Transpiled file: '$absoluteFilePath'" +
-              s"\n\t* Origin: '$sourceFilePath'")
-          Some(SourceMapOrigin(sourceFilePath.path, Some(sourceMap), sourceFileMapping))
-        }
+        case Success(sourceMap) =>
+          val sourceFileNames = sourceMap.getSources.asScala.filter(_ != null)
+          // The source file might not exist, e.g., if it was the result of transpilation
+          // but is not delivered and still referenced in the source map
+          // (fix for: https://github.com/ShiftLeftSecurity/product/issues/4994)
+          val sourceFile = sourceFileNames
+            .find(_.toLowerCase.endsWith(File(absoluteFilePath).nameWithoutExtension + VUE_SUFFIX))
+            .orElse(sourceFileNames.headOption)
+
+          sourceFile.flatMap { sourceFileName =>
+            val sourceFilePath = constructSourceFilePath(sourceFileName)
+            if (!sourceFilePath.exists) {
+              logger.debug(
+                s"Could not load source map file for '$originalFilePath'. The source map file refers to '$sourceFilePath' but this does not exist")
+              None
+            } else {
+              val sourceFileMapping = FileUtils.contentMapFromFile(Paths.get(mapFilePath))
+              logger.debug(
+                s"Successfully loaded source map file '$mapFilePath':" +
+                  s"\n\t* Transpiled file: '$absoluteFilePath'" +
+                  s"\n\t* Origin: '$sourceFilePath'")
+              Some(SourceMapOrigin(sourceFilePath.path, Some(sourceMap), sourceFileMapping))
+            }
+          }
       }
     }
   }


### PR DESCRIPTION
Source maps may be completely empty (from empty/non-existing files) or contain invalid json content
(e.g., due to encoding or out-dated/non-supported source map version).

Both is un-parsable by `com.atlassian.sourcemap.ReadableSourceMap` and leads to exceptions.
We do not want to crash on that.