### PR TITLE
Fixed source map code re-mapping

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -133,7 +133,7 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
                 s"Could not load source map file for '$originalFilePath'. The source map file refers to '$sourceFilePath' but this does not exist")
               None
             } else {
-              val sourceFileMapping = FileUtils.contentMapFromFile(Paths.get(mapFilePath))
+              val sourceFileMapping = FileUtils.contentMapFromFile(sourceFilePath.path)
               logger.debug(
                 s"Successfully loaded source map file '$mapFilePath':" +
                   s"\n\t* Transpiled file: '$absoluteFilePath'" +


### PR DESCRIPTION
We need to generate the original source code content map from the original file the transpiled file comes from.
Previously, we had loaded the source map file itself which is plain wrong.