### PR TITLE
updateDependencies.sh: use maven repo as source of truth

### DIFF
--- a/updateDependencies.sh
+++ b/updateDependencies.sh
@@ -1,27 +1,79 @@
 #!/usr/bin/env bash
 NON_INTERACTIVE_OPTION=$1
+DEPENDENCY=$2
+
+check_installed() {
+  if ! type "$1" > /dev/null; then
+    echo "Please ensure you have $1 installed."
+    exit 1
+  fi
+}
+
+check_installed curl
+
+# check if xmllint is installed
+if type xmllint > /dev/null; then
+  USE_XMLLINT=1 #true
+else
+  echo "warning: xmllint is not installed - will try with 'grep' as a fallback..."
+  USE_XMLLINT=0 #false
+fi
+
+declare -A repos=(
+  [cpg]=https://repo1.maven.org/maven2/io/shiftleft/codepropertygraph-schema_3
+  [joern]=https://repo1.maven.org/maven2/io/joern/console_2.13
+)
+
+function latest_version {
+  local NAME=$1
+  local REPO_URL=${repos[$NAME]}
+  local MVN_META_URL=$REPO_URL/maven-metadata.xml
+  local CURL_PARAMS="--silent --show-error $MVN_META_URL"
+
+  if (( $USE_XMLLINT ))
+  then
+    curl $CURL_PARAMS | xmllint --xpath "/metadata/versioning/latest/text()" -
+  else
+    curl $CURL_PARAMS | grep '<latest>' | sed 's/[ ]*<latest>\([0-9.]*\)<\/latest>/\1/'
+  fi
+}
 
 function update {
   local NAME=$1
-  local REPO=$2
+  if [[ -z "${repos[$NAME]}" ]]; then
+    echo "error: no repo url defined for $NAME"
+    exit 1;
+  fi
 
-  local HIGHEST_TAG=`git ls-remote --tags $REPO | awk -F"/" '{print $3}' | grep '^v[0-9]*\.[0-9]*\.[0-9]*' | grep -v {} | sort --version-sort | tail -n1`
-  # drop initial v from git tag
-  local VERSION=${HIGHEST_TAG:1}
+  local VERSION=$(latest_version $NAME)
   local SEARCH="val ${NAME}Version\([ ]*\)= .*"
-  local REPLACE="val ${NAME}Version\1= \"$VERSION\""
+  local OLD_VERSION=$(grep "$SEARCH" build.sbt | sed 's/.*"\(.*\)"/\1/')
 
-  if [ "$NON_INTERACTIVE_OPTION" == "--non-interactive" ]; then
-    echo "non-interactive mode, auto-updating all dependencies"
-    sed -i "s/$SEARCH/$REPLACE/" build.sbt
+  if [ "$VERSION" == "$OLD_VERSION" ]
+  then
+    echo "$NAME: unchanged ($VERSION)"
   else
-    echo "set version for $NAME to $VERSION? [Y/n]"
-    read ANSWER
-    if [ -z $ANSWER ] || [ "y" == $ANSWER ] || [ "Y" == $ANSWER ]; then
+    local REPLACE="val ${NAME}Version\1= \"$VERSION\""
+
+    if [ "$NON_INTERACTIVE_OPTION" == "--non-interactive" ]
+    then
+      echo "non-interactive mode, auto-updating $NAME: $OLD_VERSION -> $VERSION"
       sed -i "s/$SEARCH/$REPLACE/" build.sbt
+    else
+      echo "update $NAME: $OLD_VERSION -> $VERSION? [Y/n]"
+      read ANSWER
+      if [ -z $ANSWER ] || [ "y" == $ANSWER ] || [ "Y" == $ANSWER ]
+      then
+        sed -i "s/$SEARCH/$REPLACE/" build.sbt
+      fi
     fi
   fi
 }
 
-update cpg git@github.com:ShiftLeftSecurity/codepropertygraph.git
-update joern git@github.com:joernio/joern.git
+if [ "$DEPENDENCY" == "" ]; then
+  update cpg
+  update joern
+else
+  DEPENDENCY="${DEPENDENCY#--only=}"
+  update $DEPENDENCY
+fi


### PR DESCRIPTION
* now looks at maven repo rather than git tags, to determine latest version
* only ask for actual changes
* more detailed feedback, e.g. what was the old version