### PR TITLE
fetch-depth: 0 to fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Checkout LFS objects
         run: git lfs checkout
       - name: apt-get update


### PR DESCRIPTION
with a fetch-depth: 1 as before, the release plugin doesn't find the
previous tag if it's >1 commits away, like e.g. with an (unsquashed) merge commit...