### PR TITLE
Source map file path fix for vue

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -8,7 +8,7 @@ object FileDefaults {
 
   val PRIVATE_MODULES_DIR_NAME: String = "sl_private"
 
-  val WEBPACK_PREFIX: String = "webpack:///"
+  val WEBPACK_PREFIX: String = if (scala.util.Properties.isWin) "webpack://" else "webpack:/"
 
   val JS_SUFFIX: String = ".js"
 

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -8,7 +8,7 @@ object FileDefaults {
 
   val PRIVATE_MODULES_DIR_NAME: String = "sl_private"
 
-  val WEBPACK_PREFIX: String = if (scala.util.Properties.isWin) "webpack://" else "webpack:/"
+  val WEBPACK_PREFIX: String = "webpack://"
 
   val JS_SUFFIX: String = ".js"
 

--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -82,7 +82,7 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
     case _ if sourceFileName.startsWith(WEBPACK_PREFIX) =>
       // Additionally, source map files coming from webpack (e.g., from Vue transpilation) are somewhat hidden
       val replacedName = sourceFileName.replace(WEBPACK_PREFIX, "")
-      srcDir / replacedName
+      srcDir / replacedName.substring(replacedName.indexOf("/") + 1)
     case _ =>
       val cleanedPath = FileUtils.cleanPath(sourceFileName)
       // having "/" here is fine as JS source maps always have platform independent path separators

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -41,8 +41,7 @@ class TypescriptTranspiler(override val config: Config,
   override def shouldRun(): Boolean =
     config.tsTranspiling &&
       (File(projectPath) / "tsconfig.json").exists &&
-      hasTsFiles &&
-      !VueTranspiler.isVueProject(config, projectPath)
+      hasTsFiles
 
   private def moveIgnoredDirs(from: File, to: File): Unit = {
     val ignores = if (config.ignoreTests) {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -8,7 +8,6 @@ import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.io.FileDefaults.TS_SUFFIX
 import io.shiftleft.js2cpg.io.{ExternalCommand, FileUtils}
 import io.shiftleft.js2cpg.parser.TsConfigJsonParser
-import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler.isTsProject
 import org.slf4j.LoggerFactory
 import org.apache.commons.io.{FileUtils => CommonsFileUtils}
 
@@ -23,11 +22,6 @@ object TypescriptTranspiler {
 
   val DEFAULT_MODULE: String = COMMONJS
 
-  private def hasTsFiles(config: Config, projectPath: Path): Boolean =
-    FileUtils.getFileTree(projectPath, config, List(TS_SUFFIX)).nonEmpty
-
-  def isTsProject(config: Config, projectPath: Path): Boolean =
-    (File(projectPath) / "tsconfig.json").exists && hasTsFiles(config, projectPath)
 }
 
 class TypescriptTranspiler(override val config: Config,
@@ -41,8 +35,13 @@ class TypescriptTranspiler(override val config: Config,
 
   private val tsc = Paths.get(projectPath.toString, "node_modules", ".bin", "tsc").toString
 
+  private def hasTsFiles: Boolean =
+    FileUtils.getFileTree(projectPath, config, List(TS_SUFFIX)).nonEmpty
+
   override def shouldRun(): Boolean =
-    config.tsTranspiling && isTsProject(config, projectPath)
+    config.tsTranspiling &&
+      (File(projectPath) / "tsconfig.json").exists &&
+      hasTsFiles
 
   private def moveIgnoredDirs(from: File, to: File): Unit = {
     val ignores = if (config.ignoreTests) {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -34,9 +34,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private lazy val NODE_OPTIONS: Map[String, String] = nodeOptions()
 
-  override def shouldRun(): Boolean =
-    config.vueTranspiling && isVueProject(config, projectPath) &&
-      !TypescriptTranspiler.isTsProject(config, projectPath)
+  override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
     // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -34,7 +34,9 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private lazy val NODE_OPTIONS: Map[String, String] = nodeOptions()
 
-  override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
+  override def shouldRun(): Boolean =
+    config.vueTranspiling && isVueProject(config, projectPath) &&
+      !TypescriptTranspiler.isTsProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
     // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -63,8 +63,20 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
     }
   }
 
+  private def createCustomBrowserslistFile(): Unit = {
+    val browserslistFile = File(projectPath) / ".browserslistrc"
+    if (browserslistFile.exists) {
+      browserslistFile.delete(swallowIOExceptions = true)
+    }
+    val customBrowserslistFile = File
+      .newTemporaryFile(".browserslistrc", parent = Some(projectPath))
+      .deleteOnExit(swallowIOExceptions = true)
+    customBrowserslistFile.writeText("last 2 years")
+  }
+
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installVuePlugins()) {
+      createCustomBrowserslistFile()
       val vue = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
       val command =
         s"${ExternalCommand.toOSCommand(vue)} build --dest $tmpTranspileDir --mode development --no-clean"

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -259,6 +259,10 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         (File(nodeModulesZipB).unzipTo(destination = tmpProjectPath / "b") / "node_modules" / ".bin" / "tsc").toJava
           .setExecutable(true, false)
 
+        (tmpProjectPath / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+        (tmpProjectPath / "a" / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+        (tmpProjectPath / "b" / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
         Js2CpgMain.main(
           Array(tmpProjectPath.pathAsString, "--output", cpgPath, "--with-node-modules-folder"))
@@ -290,6 +294,10 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         (File(nodeModulesZipB).unzipTo(destination = tmpProjectPath / "b") / "node_modules" / ".bin" / "tsc").toJava
           .setExecutable(true, false)
 
+        (tmpProjectPath / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+        (tmpProjectPath / "a" / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+        (tmpProjectPath / "b" / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
+
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
         Js2CpgMain.main(
           Array(tmpProjectPath.pathAsString, "--output", cpgPath, "--with-node-modules-folder"))
@@ -313,6 +321,8 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
         (File(nodeModulesZip).unzipTo(destination = tmpProjectPath) / "node_modules" / ".bin" / "vue-cli-service").toJava
           .setExecutable(true, false)
+        (tmpProjectPath / "node_modules" / ".bin" / "tsc").toJava.setExecutable(true, false)
+        (tmpProjectPath / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
         Js2CpgMain.main(
@@ -336,6 +346,8 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
         (File(nodeModulesZip).unzipTo(destination = tmpProjectPath) / "node_modules" / ".bin" / "vue-cli-service").toJava
           .setExecutable(true, false)
+        (tmpProjectPath / "node_modules" / ".bin" / "tsc").toJava.setExecutable(true, false)
+        (tmpProjectPath / "node_modules" / ".bin" / "babel").toJava.setExecutable(true, false)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
         Js2CpgMain.main(
@@ -346,9 +358,14 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
             .loadFromOverflowDb(
               CpgLoaderConfig.withDefaults.withOverflowConfig(
                 Config.withDefaults.withStorageLocation(cpgPath)))
+        List("src/views/AboutPage.vue", "src/App.vue", "src/main.ts", "src/router/index.ts")
+
         fileNames(cpg) should contain theSameElementsAs List(
           s"src${java.io.File.separator}views${java.io.File.separator}AboutPage.vue",
-          s"src${java.io.File.separator}App.vue")
+          s"src${java.io.File.separator}App.vue",
+          s"src${java.io.File.separator}main.ts",
+          s"src${java.io.File.separator}router${java.io.File.separator}index.ts"
+        )
       }
     }
 

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -358,7 +358,6 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
             .loadFromOverflowDb(
               CpgLoaderConfig.withDefaults.withOverflowConfig(
                 Config.withDefaults.withStorageLocation(cpgPath)))
-        List("src/views/AboutPage.vue", "src/App.vue", "src/main.ts", "src/router/index.ts")
 
         fileNames(cpg) should contain theSameElementsAs List(
           s"src${java.io.File.separator}views${java.io.File.separator}AboutPage.vue",


### PR DESCRIPTION
* Source map file path fix for vue
* Also run tsc for vue projects
* Set .browserslistrc explicitly to avoid duplicates from auto-generated legacy code

This is for: https://github.com/ShiftLeftSecurity/product/issues/9382