### PR TITLE
map JS comma operator to BLOCK nodes

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/CallLinkerPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/CallLinkerPass.scala
@@ -91,14 +91,9 @@ class CallLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
       } else {
         getReceiverIdentifierName(call) match {
           case Some(name) =>
-            try {
-              for (method <- methodsByNameAndFile.get((call.method.filename, name))) {
-                diffGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
-              }
-            } catch {
-              case nse: NoSuchElementException =>
-                // Temporary workaround for crash in #7484
-                logger.error(s"failed to link call site for $name", nse)
+            for (file   <- call.file.headOption;
+                 method <- methodsByNameAndFile.get((file.name, name))) {
+              diffGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
             }
           case None =>
         }

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/CallLinkerPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/CallLinkerPass.scala
@@ -1,32 +1,34 @@
 package io.shiftleft.js2cpg.cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{nodes, DispatchTypes, EdgeTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.traversal.{NodeOps, jIteratortoTraversal}
 
 import scala.collection.mutable
 
 /**
-  * This pass links call sites (by full name) and call sites to methods in the same file (by name).
+  * The Javascript specific call linker links static call sites (by full name) and
+  * call sites to methods in the same file (by name).
   */
 class CallLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
-
-  private val JS_EXPORT_NAMES = IndexedSeq("module.exports", "exports")
+  import CallLinkerPass.logger
 
   private type MethodsByNameAndFileType = mutable.HashMap[(String, String), nodes.Method]
   private type MethodsByFullNameType    = mutable.HashMap[String, nodes.Method]
 
   private def isStaticSingleAssignmentLocal(ident: nodes.Identifier): Boolean =
     ident.refsTo
-      .filter(_.isInstanceOf[nodes.Local])
-      .cast[nodes.Local]
+      .collectAll[nodes.Local]
       .referencingIdentifiers
       .argumentIndex(1)
       .inCall
-      .name(Operators.assignment + ".*")
+      .assignments
       .size == 1
+
+  private val JS_EXPORT_NAMES = IndexedSeq("module.exports", "exports")
 
   private def createMethodsByNameAndFile(): (MethodsByNameAndFileType, MethodsByFullNameType) = {
     val methodsByNameAndFile = new MethodsByNameAndFileType()
@@ -46,18 +48,21 @@ class CallLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
         .inCall
         .nameExact(Operators.assignment)
         .argument(1)
-        .collectFirst {
+        .flatMap {
           case assignee: nodes.Identifier
               if isStaticSingleAssignmentLocal(assignee) && assignee.method.name == ":program" =>
-            assignee.name
+            Some(assignee.name)
           case assignee: nodes.Call
               if assignee.methodFullName == Operators.fieldAccess &&
                 JS_EXPORT_NAMES.contains(assignee.argument(1).code) =>
-            assignee
-              .argument(2)
-              .asInstanceOf[nodes.FieldIdentifier]
-              .canonicalName
+            Some(
+              assignee
+                .argument(2)
+                .asInstanceOf[nodes.FieldIdentifier]
+                .canonicalName)
+          case _ => None
         }
+        .headOption
         .foreach { name =>
           methodsByNameAndFile.put((method.filename, name), method)
         }
@@ -68,38 +73,77 @@ class CallLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(): Iterator[DiffGraph] = {
     val (methodsByNameAndFileType, methodsByFullName) = createMethodsByNameAndFile()
-    val diffGraph                                     = linkCallsites(methodsByNameAndFileType, methodsByFullName)
+
+    val diffGraph = linkCallsites(methodsByNameAndFileType, methodsByFullName)
+
     Iterator(diffGraph)
   }
 
   private def linkCallsites(methodsByNameAndFile: MethodsByNameAndFileType,
                             methodsByFullName: MethodsByFullNameType): DiffGraph = {
     val diffGraph = DiffGraph.newBuilder
+
     cpg.call.foreach { call =>
       if (call.dispatchType == DispatchTypes.STATIC_DISPATCH) {
-        methodsByFullName.get(call.methodFullName).foreach { method =>
+        for (method <- methodsByFullName.get(call.methodFullName)) {
           diffGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
         }
       } else {
-        getReceiverIdentifierName(call).foreach { name =>
-          for (file   <- call.file.headOption;
-               method <- methodsByNameAndFile.get((file.name, name))) {
-            diffGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
-          }
+        getReceiverIdentifierName(call) match {
+          case Some(name) =>
+            try {
+              for (method <- methodsByNameAndFile.get((call.method.filename, name))) {
+                diffGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
+              }
+            } catch {
+              case nse: NoSuchElementException =>
+                // Temporary workaround for crash in #7484
+                logger.error(s"failed to link call site for $name", nse)
+            }
+          case None =>
         }
       }
     }
+
     diffGraph.build()
   }
-
   private def callReceiverOption(callNode: nodes.Call): Option[nodes.Expression] =
-    callNode._receiverOut.nextOption() map (_.asInstanceOf[nodes.Expression])
+    callNode._receiverOut.nextOption().map(_.asInstanceOf[nodes.Expression])
 
   // Obtain method name for dynamic calls where the receiver is an identifier.
   private def getReceiverIdentifierName(call: nodes.Call): Option[String] = {
-    callReceiverOption(call).collect {
-      case identifier: nodes.Identifier => identifier.name
+    def fromFieldAccess(c: nodes.Call) =
+      if (c.methodFullName == Operators.fieldAccess && JS_EXPORT_NAMES.contains(c.argument(1).code)) {
+        Some(c.argument(2).code)
+      } else {
+        None
+      }
+
+    callReceiverOption(call) match {
+      case Some(callReceiver) =>
+        callReceiver match {
+          case identifier: nodes.Identifier =>
+            Some(identifier.name)
+          case block: nodes.Block =>
+            block.astChildren.lastOption
+              .collect { case c: nodes.Call => c }
+              .flatMap(fromFieldAccess)
+          case call: nodes.Call =>
+            // TODO: remove this if, once we no longer care about compat with CPGs from January 2022 (comma operator is now a block)
+            if (call.methodFullName == "<operator>.commaright")
+              call.argumentOption(2).isCall.headOption.flatMap(fromFieldAccess)
+            else
+              fromFieldAccess(call)
+          case _ =>
+            None
+        }
+      case None =>
+        None
     }
   }
 
+}
+
+object CallLinkerPass {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[CallLinkerPass])
 }

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -1619,7 +1619,7 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
     val rhsId = commaop.getRhs.accept(this)
 
     // generate the exact same code value that we used to when this was handled through `convertSimpleBinaryOp`
-    val code = astNodeBuilder.codeOf(lhsId) + " , " + astNodeBuilder.codeOf(rhsId)
+    val code    = astNodeBuilder.codeOf(lhsId) + " , " + astNodeBuilder.codeOf(rhsId)
     val blockId = astNodeBuilder.createBlockNode(commaop, customCode = Some(code))
 
     astEdgeBuilder.addAstEdge(lhsId, blockId, 0)

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -1390,6 +1390,8 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
       case (_ @(TokenType.ASSIGN | TokenType.ASSIGN_INIT),
             _ @(_: ObjectNode | _: ArrayLiteralNode)) =>
         convertDestructingAssignment(binaryNode, None)
+      case _ if binaryNode.tokenType() == TokenType.COMMARIGHT =>
+        convertCommaOp(binaryNode)
       case _ => convertSimpleBinaryOp(binaryNode)
     }
   }
@@ -1610,6 +1612,19 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
     astEdgeBuilder.addAstEdge(returnTmpId, blockId, blockOrder)
     scope.popScope()
     localAstParentStack.pop()
+    blockId
+  }
+  private def convertCommaOp(commaop: BinaryNode): NewBlock = {
+    val lhsId = commaop.getLhs.accept(this)
+    val rhsId = commaop.getRhs.accept(this)
+
+    // generate the exact same code value that we used to when this was handled through `convertSimpleBinaryOp`
+    val code = astNodeBuilder.codeOf(lhsId) + " , " + astNodeBuilder.codeOf(rhsId)
+    val blockId = astNodeBuilder.createBlockNode(commaop, customCode = Some(code))
+
+    astEdgeBuilder.addAstEdge(lhsId, blockId, 0)
+    astEdgeBuilder.addAstEdge(rhsId, blockId, 1)
+
     blockId
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstHelpers.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstHelpers.scala
@@ -50,7 +50,6 @@ object AstHelpers {
     case TokenType.ASSIGN_SAR     => Operators.assignmentArithmeticShiftRight
     case TokenType.ASSIGN_SHR     => Operators.assignmentLogicalShiftRight
     // others
-    case TokenType.COMMARIGHT     => "<operator>.commaright"
     case TokenType.COMMALEFT      => "<operator>.commaleft"
     case TokenType.IN             => "<operator>.in"
     case TokenType.NULLISHCOALESC => "<operator>.nullishcoalesc"

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -391,7 +391,9 @@ class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
     modifier
   }
 
-  def createBlockNode(node: Node, keepWholeCode: Boolean = false, customCode: Option[String] = None): NewBlock = {
+  def createBlockNode(node: Node,
+                      keepWholeCode: Boolean = false,
+                      customCode: Option[String] = None): NewBlock = {
     val lineColumn = lineAndColumn(node)
     val line       = lineColumn.line
     val column     = lineColumn.column

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -391,14 +391,14 @@ class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
     modifier
   }
 
-  def createBlockNode(node: Node, isProgramBlock: Boolean = false): NewBlock = {
+  def createBlockNode(node: Node, keepWholeCode: Boolean = false, customCode: Option[String] = None): NewBlock = {
     val lineColumn = lineAndColumn(node)
     val line       = lineColumn.line
     val column     = lineColumn.column
-    val code = if (isProgramBlock) {
-      sanitizeCode(node)
+    val code = if (keepWholeCode) {
+      customCode.getOrElse(sanitizeCode(node))
     } else {
-      shortenCode(sanitizeCode(node))
+      shortenCode(customCode.getOrElse(sanitizeCode(node)))
     }
     val block = NewBlock()
       .typeFullName(Defines.ANY.label)

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/AstCreationPassTest.scala
@@ -68,9 +68,9 @@ class AstCreationPassTest extends AbstractPassTest {
         assignment.checkNodeCount(1)
         assignment.checkProperty(PropertyNames.NAME, Operators.assignment)
 
-        def commaRight = assignment.expandAst(NodeTypes.CALL)
+        def commaRight = assignment.expandAst(NodeTypes.BLOCK)
         commaRight.checkNodeCount(1)
-        commaRight.checkProperty(PropertyNames.NAME, "<operator>.commaright") // we do not have a define for this
+        commaRight.expandAst().checkNodeCount(2)
 
         def refForConstructor = commaRight.expandAst(NodeTypes.TYPE_REF)
         refForConstructor.checkNodeCount(1)

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -26,8 +26,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf("class Foo") shouldBe expected(("bar", AlwaysEdge))
         succOf("bar") shouldBe expected(("this", AlwaysEdge))
         succOf("this") shouldBe expected(("bar()", AlwaysEdge))
-        succOf("bar()") shouldBe expected(("class Foo , bar()", AlwaysEdge))
-        succOf("class Foo , bar()") shouldBe expected(("x = class Foo , bar()", AlwaysEdge))
+        succOf("bar()") shouldBe expected(("x = class Foo , bar()", AlwaysEdge))
         succOf("x = class Foo , bar()") shouldBe expected(("RET", AlwaysEdge))
       }
     }


### PR DESCRIPTION
TypeScript sometimes produces calls in the form

    (0, functionName)(params)

Translating this as previously to <operator>.commaright caused us to not
be able to resolve the callee to "functionName". This just works when we
use a BLOCK - which has the same semantics as the JS comma operator.

As always with AST changes there's some risk of breaking stuff.
I've tried to minimize this by using the same code field as previously
(even though it's invalid JavaScript in cases like this one).

Our test suites are happy with the change. There is one explicit
reference to the operator in CS that's easy enough to adapt.

We've also had a bunch of bugs over time where passes were doing string
matching on calls and ended up matching both the intended call and an
comma operator they were contained in - or were accidentally matching
unrelated arguments of the comma operator. Most of these should be fixed
by now, but I still feel this change fixes more such bugs than it
introduces in passes that actually try to deal with the comma operator.