### PR TITLE
Set code field for all methods

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstCreator.scala
@@ -311,9 +311,7 @@ class AstCreator(diffGraph: DiffGraph.Builder, source: JsSource, usedIdentNodes:
 
     val (methodName, methodFullName) = calcMethodNameAndFullName(functionNode)
 
-    val methodId = astNodeBuilder.createMethodNode(methodName,
-                                                   methodFullName,
-                                                   astNodeBuilder.lineAndColumn(functionNode))
+    val methodId = astNodeBuilder.createMethodNode(methodName, methodFullName, functionNode)
     addMethodToAst(methodId)
 
     if (!functionNode.isProgram) {

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -7,8 +7,8 @@ import io.shiftleft.js2cpg.cpg.datastructures.{LineAndColumn, OrderTracker}
 import io.shiftleft.js2cpg.cpg.datastructures.scope.{MethodScope, Scope}
 import io.shiftleft.js2cpg.cpg.passes.Defines
 import io.shiftleft.js2cpg.parser.JsSource
+import io.shiftleft.js2cpg.parser.JsSource.shortenCode
 import io.shiftleft.passes.DiffGraph
-import org.apache.commons.lang.StringUtils
 
 class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
                                       private val astEdgeBuilder: AstEdgeBuilder,
@@ -22,10 +22,6 @@ class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
     case code: HasCode => code.code
     case _             => ""
   }
-
-  private val MAX_CODE_LENGTH: Int = 1000
-
-  private def shortenCode(code: String): String = StringUtils.abbreviate(code, MAX_CODE_LENGTH)
 
   def lineAndColumn(node: Node): LineAndColumn = {
     LineAndColumn(source.getLine(node), source.getColumn(node))
@@ -366,16 +362,16 @@ class AstNodeBuilder[NodeBuilderType](private val diffGraph: DiffGraph.Builder,
 
   def createMethodNode(methodName: String,
                        methodFullName: String,
-                       lineAndColumn: LineAndColumn): NewMethod = {
-    val line   = lineAndColumn.line
-    val column = lineAndColumn.column
-    // TODO: we might want to fix this later:
-    val code = methodFullName
+                       functionNode: FunctionNode): NewMethod = {
+    val lineColumn = lineAndColumn(functionNode)
+    val line       = lineColumn.line
+    val column     = lineColumn.column
+    val code       = shortenCode(sanitizeCode(functionNode))
 
     val method = NewMethod()
       .name(methodName)
       .filename(source.filePath)
-      .code(shortenCode(code))
+      .code(code)
       .fullName(methodFullName)
       .isExternal(false)
       .lineNumber(line)

--- a/src/test/scala/io/shiftleft/js2cpg/calllinker/CallLinkerPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/calllinker/CallLinkerPassTest.scala
@@ -7,8 +7,6 @@ import io.shiftleft.js2cpg.core.Js2CpgMain
 import io.shiftleft.semanticcpg.language.toMethodForCallGraph
 import io.shiftleft.semanticcpg.language.toNodeTypeStarters
 import io.shiftleft.semanticcpg.language.NoResolve
-import io.shiftleft.semanticcpg.language.toCfgNodeMethods
-import io.shiftleft.semanticcpg.language.toTraversal
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.Inside
@@ -41,7 +39,6 @@ class CallLinkerPassTest extends AnyWordSpec with Matchers with Inside {
         inside(cpg.method("sayhi").l) {
           case List(m) =>
             m.name shouldBe "sayhi"
-            m.code should endWith(".js::program:sayhi")
             m.fullName should endWith(".js::program:sayhi")
         }
 

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -188,8 +188,8 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf("2") shouldBe expected(("_tmp_0.key2 = 2", AlwaysEdge))
 
         succOf("_tmp_0.key2 = 2") shouldBe expected(("_tmp_0", 2, AlwaysEdge))
-        succOf("_tmp_0", 2) shouldBe expected(("x = {\n key1: \"value\",\n key2: 2\n}", AlwaysEdge))
-        succOf("x = {\n key1: \"value\",\n key2: 2\n}") shouldBe expected(("RET", AlwaysEdge))
+        succOf("_tmp_0", 2) shouldBe expected(("x = { key1: \"value\", key2: 2 }", AlwaysEdge))
+        succOf("x = { key1: \"value\", key2: 2 }") shouldBe expected(("RET", AlwaysEdge))
       }
     }
 

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -103,14 +103,18 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
                 Config.withDefaults.withStorageLocation(cpgPath)))
         fileNames(cpg) should contain theSameElementsAs List("foo.js")
         codeFields(cpg) should contain allElementsOf List(
+          "__ecma.Array.factory()",
           "_tmp_1 = __ecma.Array.factory()",
           "_tmp_1.push(1)",
+          "_tmp_1.push",
           "_tmp_1.push(2)",
+          "_tmp_1.push",
           "_tmp_1.push(3)",
-          "(_tmp_0 = [1, 2, 3 [...])",
-          "(_tmp_0 = [1, 2, 3 [...]).map",
+          "_tmp_1.push",
+          "(_tmp_0 = [1, 2, 3].map((n) => n + 1);)",
+          "(_tmp_0 = [1, 2, 3].map((n) => n + 1);).map",
           "n + 1",
-          "[1, 2, 3 [...].map(anonymous)"
+          "[1, 2, 3].map((n) => n + 1);.map(anonymous)"
         )
       }
 


### PR DESCRIPTION
Capped with number of chars: 50 >= code field length <= 1000 (multiple whitespace and newlines are replaced)
This gives a nice overview for methods (especially for anonymous functions) when debugging / traversing the CPG.