### PR TITLE
Fixed subproject discovery and yarn/npm commands

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -76,7 +76,7 @@ class Js2Cpg {
   private def findProjects(projectDir: File, config: Config): List[Path] = {
     val allProjects = FileUtils
       .getFileTree(projectDir.path, config, List(".json"))
-      .filter(_.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME))
+      .filter(PackageJsonParser.isValidProjectPackageJson)
       .map(_.getParent)
       .sortBy(_.toString)
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -21,9 +21,9 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
 
   private def installPugPlugins(): Boolean = {
     val command = if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} pug-cli --dev && ${TranspilingEnvironment.YARN_INSTALL}"
+      s"${TranspilingEnvironment.YARN_ADD} pug-cli && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"${TranspilingEnvironment.NPM_INSTALL} --save-dev pug-cli && ${TranspilingEnvironment.NPM_INSTALL}"
+      s"${TranspilingEnvironment.NPM_INSTALL} pug-cli && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.info("Installing Pug dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing Pug plugins with command '$command' in path '$projectPath'")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -31,9 +31,9 @@ case class TranspilerGroup(
 
   private def installPlugins(): Boolean = {
     val command = if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} $BABEL_PLUGINS --dev -W && ${TranspilingEnvironment.YARN_INSTALL}"
+      s"${TranspilingEnvironment.YARN_ADD} $BABEL_PLUGINS && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"${TranspilingEnvironment.NPM_INSTALL} --save-dev $BABEL_PLUGINS && ${TranspilingEnvironment.NPM_INSTALL}"
+      s"${TranspilingEnvironment.NPM_INSTALL} $BABEL_PLUGINS && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.info("Installing project dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing plugins with command '$command' in path '$projectPath'")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -17,11 +17,11 @@ object TranspilingEnvironment {
   val NPM: String  = ExternalCommand.toOSCommand("npm")
 
   val YARN_ADD: String =
-    s"$YARN add --prefer-offline --ignore-scripts --legacy-peer-deps"
+    s"$YARN --prefer-offline --ignore-scripts --legacy-peer-deps --dev -W add"
   val YARN_INSTALL: String =
-    s"$YARN install --prefer-offline --ignore-scripts --legacy-peer-deps"
+    s"$YARN --prefer-offline --ignore-scripts --legacy-peer-deps install"
   val NPM_INSTALL: String =
-    s"$NPM install --prefer-offline --no-audit --progress=false --ignore-scripts --legacy-peer-deps"
+    s"$NPM --prefer-offline --no-audit --progress=false --ignore-scripts --legacy-peer-deps --save-dev install"
 }
 
 trait TranspilingEnvironment {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -91,9 +91,9 @@ class TypescriptTranspiler(
 
   private def installTsPlugins(): Boolean = {
     val command = if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} typescript --dev"
+      s"${TranspilingEnvironment.YARN_ADD} typescript"
     } else {
-      s"${TranspilingEnvironment.NPM_INSTALL} --save-dev typescript"
+      s"${TranspilingEnvironment.NPM_INSTALL} typescript"
     }
     logger.info("Installing TypeScript dependencies and plugins. That will take a while.")
     logger.debug(

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -47,9 +47,9 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private def installVuePlugins(): Boolean = {
     val command = if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} @vue/cli-service-global --dev && ${TranspilingEnvironment.YARN_INSTALL}"
+      s"${TranspilingEnvironment.YARN_ADD} @vue/cli-service-global && ${TranspilingEnvironment.YARN_INSTALL}"
     } else {
-      s"${TranspilingEnvironment.NPM_INSTALL} --save-dev @vue/cli-service-global && ${TranspilingEnvironment.NPM_INSTALL}"
+      s"${TranspilingEnvironment.NPM_INSTALL} @vue/cli-service-global && ${TranspilingEnvironment.NPM_INSTALL}"
     }
     logger.info("Installing Vue.js dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing Vue.js plugins with command '$command' in path '$projectPath'")

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPassTest.scala
@@ -12,6 +12,38 @@ class DependenciesPassTest extends AbstractPassTest {
 
   "DependenciesPass" should {
 
+    "ignore empty package.json" in {
+      File.usingTemporaryDirectory("js2cpgTest") { dir =>
+        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        json.write("")
+        PackageJsonParser.isValidProjectPackageJson(json.path) shouldBe false
+      }
+    }
+
+    "ignore package.json without any useful content" in {
+      File.usingTemporaryDirectory("js2cpgTest") { dir =>
+        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        json.write("""
+            |{
+            |  "name": "something",
+            |  "version": "0.1.0",
+            |  "description": "foobar",
+            |  "main": "./target_node/index.js",
+            |  "private": true
+            |}
+            |""".stripMargin)
+        PackageJsonParser.isValidProjectPackageJson(json.path) shouldBe false
+      }
+    }
+
+    "ignore package.json without dependencies" in {
+      File.usingTemporaryDirectory("js2cpgTest") { dir =>
+        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        json.write("{}")
+        PackageJsonParser.isValidProjectPackageJson(json.path) shouldBe false
+      }
+    }
+
     "generate dependency nodes correctly (no dependencies at all)" in DependencyFixture("", "{}") {
       cpg =>
         getDependencies(cpg).size shouldBe 0


### PR DESCRIPTION
Subprojects without a valid package.json (non-empty and has at least one dependency) are ignored now.
This reduces npm/yarn install failure noise drastically.
Transpiling those projects failed anyway as installing the plugins failed in first place, so we are not losing anything.

Also: fixed npm/yarn add and install commands. All parameter need to go first there.

This is mostly for: https://github.com/ShiftLeftSecurity/product/issues/9840