### PR TITLE
adapt to upstream changes: passes api, semanticcpg->joern/x2cpg move

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,7 @@ lazy val commonSettings = Seq(
     "org.apache.logging.log4j"   % "log4j-slf4j-impl"  % "2.17.2"     % Runtime,
     "io.joern"                  %% "dataflowengineoss" % joernVersion % Test,
     "io.shiftleft"              %% "semanticcpg"       % cpgVersion   % Test classifier "tests",
+    "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.11"     % Test
   ),
   Test / fork := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-val cpgVersion   = "1.3.504"
-val joernVersion = "1.1.579"
+val cpgVersion   = "1.3.514"
+val joernVersion = "1.1.605"
 
 val gitCommitString = SettingKey[String]("gitSha")
 

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/BuiltinTypesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/BuiltinTypesPass.scala
@@ -1,17 +1,17 @@
 package io.shiftleft.js2cpg.cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNamespaceBlock, NewType, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.js2cpg.cpg.datastructures.OrderTracker
+import io.shiftleft.passes.{DiffGraph, KeyPool, SimpleCpgPass}
 import org.slf4j.LoggerFactory
 
-class BuiltinTypesPass(cpg: Cpg, keyPool: KeyPool) extends CpgPass(cpg, keyPool = Some(keyPool)) {
+class BuiltinTypesPass(cpg: Cpg, keyPool: KeyPool) extends SimpleCpgPass(cpg, keyPool = Some(keyPool)) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  override def run(): Iterator[DiffGraph] = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.debug("Generating builtin types.")
 
     val diffGraph = DiffGraph.newBuilder
@@ -45,8 +45,6 @@ class BuiltinTypesPass(cpg: Cpg, keyPool: KeyPool) extends CpgPass(cpg, keyPool 
       orderTracker.inc()
       diffGraph.addEdge(namespaceBlock, typeDecl, EdgeTypes.AST)
     }
-
-    Iterator(diffGraph.build())
   }
 
 }

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/BuiltinTypesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/BuiltinTypesPass.scala
@@ -14,8 +14,6 @@ class BuiltinTypesPass(cpg: Cpg, keyPool: KeyPool) extends SimpleCpgPass(cpg, ke
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.debug("Generating builtin types.")
 
-    val diffGraph = DiffGraph.newBuilder
-
     val namespaceBlock = NewNamespaceBlock()
       .name(Defines.GLOBAL_NAMESPACE)
       .fullName(Defines.GLOBAL_NAMESPACE)

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
@@ -1,19 +1,17 @@
 package io.shiftleft.js2cpg.cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.parser.PackageJsonParser
+import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
 
 import java.nio.file.Paths
 
-class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool) extends CpgPass(cpg, keyPool = Some(keyPool)) {
+class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool) extends SimpleCpgPass(cpg, keyPool = Some(keyPool)) {
 
-  override def run(): Iterator[DiffGraph] = {
-    val diffGraph = DiffGraph.newBuilder
-
+  override def run(diffGraph:  DiffGraphBuilder): Unit = {
     val packagesJsons =
       (FileUtils
         .getFileTree(Paths.get(config.srcDir), config, List(".json"))
@@ -29,8 +27,6 @@ class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool) extends CpgPa
         .version(version)
       diffGraph.addNode(dep)
     }
-
-    Iterator(diffGraph.build())
   }
 
 }

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/DependenciesPass.scala
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 
 class DependenciesPass(cpg: Cpg, config: Config, keyPool: KeyPool) extends SimpleCpgPass(cpg, keyPool = Some(keyPool)) {
 
-  override def run(diffGraph:  DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     val packagesJsons =
       (FileUtils
         .getFileTree(Paths.get(config.srcDir), config, List(".json"))

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
@@ -3,20 +3,17 @@ package io.shiftleft.js2cpg.cpg.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
-import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
+import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
 import org.slf4j.LoggerFactory
 
-class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool, hash: String) extends CpgPass(cpg, keyPool = Some(keyPool)) {
+class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool, hash: String) extends SimpleCpgPass(cpg, keyPool = Some(keyPool)) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  override def run(): Iterator[DiffGraph] = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.debug("Generating meta-data.")
-
-    val diffGraph = DiffGraph.newBuilder
     val metaNode  = NewMetaData().language(Languages.JAVASCRIPT).hash(hash)
     diffGraph.addNode(metaNode)
-    Iterator(diffGraph.build())
   }
 
 }

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/JsMetaDataPass.scala
@@ -12,7 +12,7 @@ class JsMetaDataPass(cpg: Cpg, keyPool: KeyPool, hash: String) extends SimpleCpg
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.debug("Generating meta-data.")
-    val metaNode  = NewMetaData().language(Languages.JAVASCRIPT).hash(hash)
+    val metaNode = NewMetaData().language(Languages.JAVASCRIPT).hash(hash)
     diffGraph.addNode(metaNode)
   }
 

--- a/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/cpg/passes/CfgCreationPassTest.scala
@@ -6,8 +6,8 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.js2cpg.core.Report
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.passes.controlflow.CfgCreationPass
-import io.shiftleft.semanticcpg.passes.controlflow.cfgcreation.Cfg._
+import io.joern.x2cpg.passes.controlflow.CfgCreationPass
+import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg._
 import overflowdb.traversal._
 import overflowdb._
 

--- a/src/test/scala/io/shiftleft/js2cpg/dataflow/DataFlowCodeToCpgSuite.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/dataflow/DataFlowCodeToCpgSuite.scala
@@ -7,7 +7,8 @@ import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.layers._
+import io.joern.x2cpg.layers._
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
 class DataFlowCodeToCpgSuite extends Js2CpgCodeToCpgSuite {
 

--- a/src/test/scala/io/shiftleft/js2cpg/dataflow/Js2CpgCodeToCpgSuite.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/dataflow/Js2CpgCodeToCpgSuite.scala
@@ -4,9 +4,10 @@ import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.js2cpg.core.{Config, Js2Cpg}
-import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
+import io.joern.x2cpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
 
 class Js2CpgFrontend(override val fileSuffix: String = ".js") extends LanguageFrontend() {
+
   override def execute(sourceCodePath: java.io.File): Cpg = {
     var cpg = Cpg.emptyCpg
     File.usingTemporaryFile("js2cpg", ".bin") { cpgFile =>


### PR DESCRIPTION
once released and upgraded in codescience, should fix this linker error  
```
java.lang.NoSuchMethodError: overflowdb.BatchedUpdate$DiffGraphBuilder.addEdge(Loverflowdb/DetachedNodeData;Loverflowdb/DetachedNodeData;Ljava/lang/String;[Ljava/lang/Object;)Loverflowdb/BatchedUpdate$DiffGraphBuilder;
```
as seen in https://ci.shiftleftsecurity.com/job/TEST-Integration-Codescience/2272/consoleFull