### PR TITLE
quieten plugin installation errors

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -33,7 +33,7 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
         logger.info("\t+ Pug plugins installed")
         true
       case Failure(exception) =>
-        logger.error("\t- Failed to install Pug plugins", exception)
+        logger.warn("\t- Failed to install Pug plugins", exception)
         false
     }
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -41,7 +41,7 @@ case class TranspilerGroup(override val config: Config, override val projectPath
         logger.info("\t+ Plugins installed")
         true
       case Failure(exception) =>
-        logger.error("\t- Failed to install plugins", exception)
+        logger.warn("\t- Failed to install plugins", exception)
         false
     }
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -101,7 +101,7 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
         logger.info("\t+ TypeScript plugins installed")
         true
       case Failure(exception) =>
-        logger.error("\t- Failed to install TypeScript plugins", exception)
+        logger.warn("\t- Failed to install TypeScript plugins", exception)
         false
     }
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -59,7 +59,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
         logger.info("\t+ Vue.js plugins installed")
         true
       case Failure(exception) =>
-        logger.error("\t- Failed to install Vue.js plugins", exception)
+        logger.warn("\t- Failed to install Vue.js plugins", exception)
         false
     }
   }


### PR DESCRIPTION
Happens a bit too often, e.g. <https://kibana.prod.sltr.io/app/kibana#/doc/a31c8fc0-76ce-11ea-9208-f38e6fc02665/logstash-2022.05.05/doc/?id=TYIVlIAB0KswhvRKYW1Z> - alternatively, can something be done about it so we don't get the errors in the first place?