### PR TITLE
Quietened tsc output w.r.t. typing issues

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -22,6 +22,9 @@ object TypescriptTranspiler {
 
   val DEFAULT_MODULE: String = COMMONJS
 
+  private val tscTypingWarnings =
+    List("error TS", ".d.ts", "The file is in the program because", "Entry point of type library")
+
 }
 
 class TypescriptTranspiler(override val config: Config, override val projectPath: Path, subDir: Option[Path] = None)
@@ -104,6 +107,9 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
     }
   }
 
+  private def isCleanTrace(exception: Throwable): Boolean =
+    exception.getMessage.linesIterator.forall(l => TypescriptTranspiler.tscTypingWarnings.exists(l.contains))
+
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installTsPlugins()) {
       File.usingTemporaryDirectory() { tmpForIgnoredDirs =>
@@ -166,11 +172,6 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
       }
     }
     true
-  }
-
-  private def isCleanTrace(exception: Throwable): Boolean = {
-    val lines = exception.getMessage.linesIterator
-    !lines.filterNot(l => l.contains("error TS") || l.contains(".d.ts")).exists(_.contains("error TS"))
   }
 
   override def validEnvironment(): Boolean = valid(projectPath)

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -13,7 +13,6 @@ import org.apache.commons.io.{FileUtils => CommonsFileUtils}
 
 import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success, Try}
-import scala.jdk.CollectionConverters._
 
 object TypescriptTranspiler {
 
@@ -169,12 +168,10 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
     true
   }
 
-  private def isCleanTrace(exception: Throwable): Boolean = !exception.getMessage
-    .lines()
-    .iterator()
-    .asScala
-    .filterNot(l => l.contains("error TS") || l.contains(".d.ts"))
-    .exists(_.contains("error TS"))
+  private def isCleanTrace(exception: Throwable): Boolean = {
+    val lines = exception.getMessage.linesIterator
+    !lines.filterNot(l => l.contains("error TS") || l.contains(".d.ts")).exists(_.contains("error TS"))
+  }
 
   override def validEnvironment(): Boolean = valid(projectPath)
 


### PR DESCRIPTION
Putting an empty array as compilerOptions types and typeRoots speeds up tsc a lot and removes tons of type checking warnings/errors (we do not care for types there anyway).
Also filtered the remaining stacktrace (if any) for tsc error codes.