### PR TITLE
Update dependencies and update to JDK 11

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v11
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
         with:
-          java-version: adopt@1.8
+          java-version: 1.11
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,9 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
-          distribution: 'adopt'
-          java-version: 8
+          java-version: 1.11
       - uses: actions/cache@v2
         with:
           path: |

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val cpgVersion   = "1.3.553"
-val joernVersion = "1.1.938"
+val joernVersion = "1.1.998"
 
 val gitCommitString = SettingKey[String]("gitSha")
 
@@ -93,7 +93,7 @@ lazy val commonSettings = Seq(
     "io.joern"                  %% "x2cpg"             % joernVersion,
     ("com.github.pathikrit"     %% "better-files"      % "3.9.1").cross(CrossVersion.for3Use2_13),
     "com.github.scopt"          %% "scopt"             % "4.1.0",
-    "org.graalvm.js"             % "js"                % "22.0.0.2",
+    "org.graalvm.js"             % "js"                % "22.2.0",
     "com.fasterxml.jackson.core" % "jackson-databind"  % "2.13.3",
     "com.atlassian.sourcemap"    % "sourcemap"         % "2.0.0",
     "commons-io"                 % "commons-io"        % "2.11.0",

--- a/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/cpg/passes/astcreation/AstNodeBuilder.scala
@@ -10,7 +10,7 @@ import io.shiftleft.js2cpg.parser.JsSource
 import io.shiftleft.js2cpg.parser.JsSource.shortenCode
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-class AstNodeBuilder[NodeBuilderType](
+class AstNodeBuilder(
   private val diffGraph: DiffGraphBuilder,
   private val astEdgeBuilder: AstEdgeBuilder,
   private val source: JsSource,
@@ -39,10 +39,11 @@ class AstNodeBuilder[NodeBuilderType](
   }
 
   def groupIdFromImportNode(importNode: ImportNode): String = {
-    importNode.getFrom match {
+    val specifier = importNode.getFrom match {
       case null => importNode.getModuleSpecifier.getValue
       case from => from.getModuleSpecifier.getValue
     }
+    specifier.toJavaStringUncached
   }
 
   def createParameterInNode(

--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -36,7 +36,7 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
   private val sourceMap        = sourceMapOrigin()
 
   private val (positionToLineNumberMapping, positionToFirstPositionInLineMapping) =
-    FileUtils.positionLookupTables(source.getString)
+    FileUtils.positionLookupTables(source.getContent)
 
   private case class SourceMapOrigin(
     sourceFilePath: Path,


### PR DESCRIPTION
Replaces:
 - https://github.com/ShiftLeftSecurity/js2cpg/pull/160
 - https://github.com/ShiftLeftSecurity/js2cpg/pull/187

@mpollmeier @Ferada  CS should be able to handle this update to JDK 11 now?
