### PR TITLE
Remove engine checks and scripts for installing transpilation plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,8 +109,11 @@ lazy val commonSettings = Seq(
 lazy val js2cpg = (project in file(".")).settings(
   commonSettings,
   name := "js2cpg",
-  Test / unmanagedResources += baseDirectory.value / "src" / "test" / "resources" / "privatemodules" / ".npmrc",
-  Test / unmanagedResources += baseDirectory.value / "src" / "test" / "resources" / "ignoreprivatemodules" / ".npmrc",
+  Test / unmanagedResources ++= Seq(
+    baseDirectory.value / "src" / "test" / "resources" / "privatemodules" / ".npmrc",
+    baseDirectory.value / "src" / "test" / "resources" / "ignoreprivatemodules" / ".npmrc",
+    baseDirectory.value / "src" / "test" / "resources" / "enginecheck" / ".npmrc"
+  ),
   Test / javaOptions ++= Seq("-Dlog4j.configurationFile=file:src/test/resources/log4j2-test.xml"),
   publishTo             := sonatypePublishToBundle.value,
   sonatypeTimeoutMillis := 7200000,

--- a/src/test/resources/enginecheck/.npmrc
+++ b/src/test/resources/enginecheck/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/src/test/resources/enginecheck/index.ts
+++ b/src/test/resources/enginecheck/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/src/test/resources/enginecheck/package.json
+++ b/src/test/resources/enginecheck/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "privatemodules",
+  "version": "0.1.0",
+  "private": true,
+  "engines" : {
+    "npm" : "<=4.0.0",
+    "node" : "<=12.0.0"
+  }
+}

--- a/src/test/resources/enginecheck/tsconfig.json
+++ b/src/test/resources/enginecheck/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["index.ts"]
+}

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -293,6 +293,34 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         lineNumbers(cpg) should contain allElementsOf List(1, 2, 4, 7, 9)
       }
 
+    "fail when running on engine restricted project" in TranspilationFixture("enginecheck") { tmpDir =>
+      File.usingTemporaryDirectory() { transpileOutDir =>
+        new TranspilationRunner(
+          tmpDir.path,
+          transpileOutDir.path,
+          core.Config(srcDir = tmpDir.pathAsString, babelTranspiling = false, optimizeDependencies = false)
+        ).execute()
+        val transpiledJsFiles = FileUtils.getFileTree(transpileOutDir.path, core.Config(), List(JS_SUFFIX))
+        transpiledJsFiles shouldBe empty
+      }
+    }
+
+    "work when running on engine restricted project with optimized dependencies" in TranspilationFixture(
+      "enginecheck"
+    ) { tmpDir =>
+      File.usingTemporaryDirectory() { transpileOutDir =>
+        new TranspilationRunner(
+          tmpDir.path,
+          transpileOutDir.path,
+          core.Config(srcDir = tmpDir.pathAsString, babelTranspiling = false, optimizeDependencies = true)
+        ).execute()
+        val transpiledJsFiles = FileUtils
+          .getFileTree(transpileOutDir.path, core.Config(), List(JS_SUFFIX))
+          .map(_.getFileName.toString)
+        transpiledJsFiles shouldBe List("index.js")
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Otherwise, the plugin installation may fail due to unfulfillable checks on the npm/nodejs version during
transpilation plugin installation. Also, the scripts section of the package.json may contain pre-/post install
hooks that may crash the installation.

For: https://github.com/ShiftLeftSecurity/product/issues/10841