### PR TITLE
clear more json keys with dependencies from package.json with optimize-dependencies

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
@@ -28,8 +28,14 @@ object PackageJsonParser {
 
   val LOCKFILES: List[String] = List(JSON_LOCK_FILENAME, YARN_LOCK_FILENAME, PNPM_LOCK_FILENAME)
 
-  val PROJECT_DEPENDENCIES: Seq[String] =
-    Seq("dependencies", "devDependencies", "peerDependencies", "optionalDependencies")
+  val PROJECT_DEPENDENCIES: Seq[String] = Seq(
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "resolutions",
+    "bundledDependencies"
+  )
 
   private val cachedDependencies: TrieMap[Path, Map[String, String]] = TrieMap.empty
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -31,7 +31,8 @@ case class TranspilerGroup(override val config: Config, override val projectPath
     val command = if (pnpmAvailable(projectPath)) {
       s"${TranspilingEnvironment.PNPM_ADD} $BABEL_PLUGINS && ${TranspilingEnvironment.PNPM_INSTALL}"
     } else if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} $BABEL_PLUGINS && ${TranspilingEnvironment.YARN_INSTALL}"
+      val verbose = if (logger.isDebugEnabled) " -v" else ""
+      s"${TranspilingEnvironment.YARN_ADD} $verbose $BABEL_PLUGINS && ${TranspilingEnvironment.YARN_INSTALL} $verbose"
     } else {
       s"${TranspilingEnvironment.NPM_INSTALL} $BABEL_PLUGINS && ${TranspilingEnvironment.NPM_INSTALL}"
     }


### PR DESCRIPTION
see https://classic.yarnpkg.com/lang/en/docs/package-json/#toc-resolutions about these new keys

hopefully this resolves ShiftLeftSecurity/product#11003

in case it does not, this also adds some verbose flags to the yarn command when debug logging is enabled