### PR TITLE
strip @babel dependencies with --optimize-dependencies + more debug logging

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -2,8 +2,8 @@ package io.shiftleft.js2cpg.preprocessing
 
 import better.files.File
 import io.shiftleft.js2cpg.core.Config
-import io.shiftleft.js2cpg.io.FileDefaults.NODE_MODULES_DIR_NAME
 import io.shiftleft.js2cpg.io.ExternalCommand
+import io.shiftleft.js2cpg.io.FileDefaults.NODE_MODULES_DIR_NAME
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}
@@ -51,7 +51,7 @@ class BabelTranspiler(
       "--plugins @babel/plugin-transform-property-mutators " +
       "--plugins @babel/plugin-transform-runtime " +
       s"--out-dir $outDir $constructIgnoreDirArgs"
-    logger.debug(s"\t+ Babel transpiling $projectPath to $outDir")
+    logger.debug(s"\t+ Babel transpiling $projectPath to $outDir with command '$command'")
     ExternalCommand.run(command, in.toString) match {
       case Success(_)         => logger.debug("\t+ Babel transpiling finished")
       case Failure(exception) => logger.debug("\t- Babel transpiling failed", exception)

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -23,7 +23,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
 
   private val transpilers: Seq[Transpiler] = createTranspilers()
 
-  private val DEPS_TO_KEEP: List[String] = List("@vue", "vue", "nuxt", "@babel")
+  private val DEPS_TO_KEEP: List[String] = List("@vue", "vue", "nuxt")
 
   private def createTranspilers(): Seq[Transpiler] = {
     // We always run the following transpilers by default when not stated otherwise in the Config.

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -91,7 +91,10 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
     val command = if (pnpmAvailable(projectPath)) {
       s"${TranspilingEnvironment.PNPM_ADD} typescript"
     } else if (yarnAvailable()) {
-      s"${TranspilingEnvironment.YARN_ADD} typescript"
+      if (logger.isDebugEnabled)
+        s"${TranspilingEnvironment.YARN_ADD} typescript"
+      else
+        s"${TranspilingEnvironment.YARN_ADD} -v typescript"
     } else {
       s"${TranspilingEnvironment.NPM_INSTALL} typescript"
     }


### PR DESCRIPTION
this is for [ShiftLeftSecurity/product#11003](https://github.com/ShiftLeftSecurity/product/issues/11003#issuecomment-1238984756)


`@babel` was added explicitly to this list in #172, but I can't find anything that would explain why. I guess it's :crossed_fingers: this won't break much. (All our tests seem happy either way.)