### PR TITLE
Ignore webpack and babel config files during transpilation

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
@@ -25,8 +25,19 @@ object PackageJsonParser {
   val PNPM_LOCK_FILENAME_BAK: String  = "pnpm-lock.yaml.bak"
   val YARN_LOCK_FILENAME: String      = "yarn.lock"
   val YARN_LOCK_FILENAME_BAK: String  = "yarn.lock.bak"
+  val WEBPACK_CONFIG_FILENAME: String = "webpack.config.js"
+  val BABEL_CONFIG_FILENAME: String   = "babel.config.js"
 
-  val LOCKFILES: List[String] = List(JSON_LOCK_FILENAME, YARN_LOCK_FILENAME, PNPM_LOCK_FILENAME)
+  val PROJECT_CONFIG_FILES: List[String] = List(
+    JSON_LOCK_FILENAME,
+    YARN_LOCK_FILENAME,
+    PNPM_LOCK_FILENAME,
+    // pnpm workspace config file is not required as we manually descent into sub-project:
+    PNPM_WS_FILENAME,
+    NPM_SHRINKWRAP_FILENAME,
+    WEBPACK_CONFIG_FILENAME,
+    BABEL_CONFIG_FILENAME
+  )
 
   val PROJECT_DEPENDENCIES: Seq[String] = Seq(
     "dependencies",

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -118,10 +118,11 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
     val packageJson = File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME
     if (config.optimizeDependencies && packageJson.exists) {
       // move config files out of the way
-      PackageJsonParser.PROJECT_CONFIG_FILES.map(File(projectPath, _)).collect {
-        case file if file.exists =>
-          file.renameTo(file.pathAsString + ".bak")
-      }
+      PackageJsonParser.PROJECT_CONFIG_FILES
+        .map(File(projectPath, _))
+        .filter(_.exists)
+        .foreach(file => file.renameTo(file.pathAsString + ".bak"))
+
       // create a temporary package.json without dependencies
       val originalContent = FileUtils.readLinesInFile(packageJson.path).mkString("\n")
       val mapper          = new ObjectMapper()
@@ -156,10 +157,10 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
       packageJson.writeText(originalContent)
 
       // restore config files
-      PackageJsonParser.PROJECT_CONFIG_FILES.map(f => File(projectPath, f + ".bak")).collect {
-        case file if file.exists =>
-          file.renameTo(file.pathAsString.stripSuffix(".bak"))
-      }
+      PackageJsonParser.PROJECT_CONFIG_FILES
+        .map(f => File(projectPath, f + ".bak"))
+        .filter(_.exists)
+        .foreach(file => file.renameTo(file.pathAsString.stripSuffix(".bak")))
     } else {
       workUnit()
     }


### PR DESCRIPTION
Having webpack.config.js or babel.config.js flying around during babel transpilation might lead to failures. Better move them away when running with --optimize-dependencies (which is the default).