### PR TITLE
Make ExternalCommand logging thread-safe

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-12]
     steps:
       - name: Checkout github repo
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,11 +12,13 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v11
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
       - name: Compile and run tests
-        run: sbt "clean; +test;"
+        run: sbt clean +test
   formatting:
     runs-on: ubuntu-20.04
     steps:
@@ -24,9 +26,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v11
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
       - name: Check formatting
         run: sbt scalafmtCheck test:scalafmtCheck
       - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt'"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,7 @@
 name: PR
 on: pull_request
+env:
+  POWERSHELL_TELEMETRY_OPTOUT: 1
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: adopt@1.8
       - name: Compile and run tests
-        run: sbt clean +test
+        run: sbt "clean; +test;"
   formatting:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,15 +15,8 @@ jobs:
         uses: olafurpg/setup-scala@v11
         with:
           java-version: adopt@1.8
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
       - name: Compile and run tests
-        run: sbt -v -Dfile.encoding=UTF-8 "clean; +test;"
-        shell: bash
+        run: sbt clean +test
   formatting:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
       - name: Run tests
         run: sbt clean +test
       - name: Release to sonatype

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,12 @@ jobs:
         run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: 8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
       - name: Run tests
         run: sbt clean +test
       - name: Release to sonatype

--- a/build.sbt
+++ b/build.sbt
@@ -102,8 +102,7 @@ lazy val commonSettings = Seq(
     "io.joern"                  %% "dataflowengineoss" % joernVersion % Test,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.12"     % Test
-  ),
-  Test / fork := true
+  )
 )
 
 lazy val js2cpg = (project in file(".")).settings(

--- a/src/main/scala/io/shiftleft/js2cpg/io/ExternalCommand.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/ExternalCommand.scala
@@ -1,32 +1,31 @@
 package io.shiftleft.js2cpg.io
 
-import java.io
-
-import scala.collection.mutable
+import java.util.concurrent.ConcurrentLinkedQueue
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters._
 
 object ExternalCommand {
 
   private val COMMAND_AND: String = " && "
   private val IS_WIN: Boolean     = scala.util.Properties.isWin
 
-  val ENV_PATH_CONTENT: String = scala.util.Properties.envOrElse("PATH", "")
-
   def toOSCommand(command: String): String = if (IS_WIN) command + ".cmd" else command
 
   def run(command: String, inDir: String = ".", extraEnv: Map[String, String] = Map.empty): Try[String] = {
-    val result                      = mutable.ArrayBuffer.empty[String]
-    val lineHandler: String => Unit = line => result += line
-    val logger                      = ProcessLogger(lineHandler, lineHandler)
-    val commands                    = command.split(COMMAND_AND).toSeq
+    val dir           = new java.io.File(inDir)
+    val stdOutOutput  = new ConcurrentLinkedQueue[String]
+    val stdErrOutput  = new ConcurrentLinkedQueue[String]
+    val processLogger = ProcessLogger(stdOutOutput.add, stdErrOutput.add)
+    val commands      = command.split(COMMAND_AND).toSeq
     commands
-      .map(cmd => Try(Process(cmd, new io.File(inDir), extraEnv.toList: _*).!(logger)).toOption.getOrElse(1))
+      .map(cmd => Try(Process(cmd, dir, extraEnv.toList: _*).!(processLogger)).getOrElse(1))
       .sum match {
       case 0 =>
-        Success(result.mkString(System.lineSeparator()))
+        Success(stdOutOutput.asScala.mkString(System.lineSeparator()))
       case _ =>
-        Failure(new RuntimeException(result.mkString(System.lineSeparator())))
+        Failure(new RuntimeException(stdErrOutput.asScala.mkString(System.lineSeparator())))
     }
   }
+
 }

--- a/src/main/scala/io/shiftleft/js2cpg/io/ExternalCommand.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/ExternalCommand.scala
@@ -24,7 +24,8 @@ object ExternalCommand {
       case 0 =>
         Success(stdOutOutput.asScala.mkString(System.lineSeparator()))
       case _ =>
-        Failure(new RuntimeException(stdErrOutput.asScala.mkString(System.lineSeparator())))
+        val allOutput = stdOutOutput.asScala ++ stdErrOutput.asScala
+        Failure(new RuntimeException(allOutput.mkString(System.lineSeparator())))
     }
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -17,6 +17,7 @@ class BabelTranspiler(
 ) extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)
+  private val babel  = Paths.get(projectPath.toString, "node_modules", ".bin", "babel").toString
 
   override def shouldRun(): Boolean =
     config.babelTranspiling && !VueTranspiler.isVueProject(config, projectPath)
@@ -35,7 +36,6 @@ class BabelTranspiler(
     val outDir =
       subDir.map(s => File(tmpTranspileDir.toString, s.toString)).getOrElse(File(tmpTranspileDir))
 
-    val babel = Paths.get(projectPath.toString, "node_modules", ".bin", "babel").toString
     val command = s"${ExternalCommand.toOSCommand(babel)} . " +
       "--no-babelrc " +
       s"--source-root '${in.toString}' " +

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -40,6 +40,7 @@ class NuxtTranspiler(override val config: Config, override val projectPath: Path
   import NuxtTranspiler._
 
   private val logger = LoggerFactory.getLogger(getClass)
+  private val nuxt   = Paths.get(projectPath.toString, "node_modules", ".bin", "nuxt").toString
 
   private def isNuxtProject: Boolean =
     PackageJsonParser
@@ -49,7 +50,6 @@ class NuxtTranspiler(override val config: Config, override val projectPath: Path
   override def shouldRun(): Boolean = config.nuxtTranspiling && isNuxtProject
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
-    val nuxt    = Paths.get(projectPath.toString, "node_modules", ".bin", "nuxt").toString
     val command = s"${ExternalCommand.toOSCommand(nuxt)} --force-exit"
     logger.debug(s"\t+ Nuxt.js transpiling $projectPath")
     ExternalCommand.run(command, projectPath.toString) match {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -12,6 +12,7 @@ import scala.util.{Failure, Success}
 class PugTranspiler(override val config: Config, override val projectPath: Path) extends Transpiler {
 
   private val logger = LoggerFactory.getLogger(getClass)
+  private val pug    = Paths.get(projectPath.toString, "node_modules", ".bin", "pug").toString
 
   private def hasPugFiles: Boolean =
     FileUtils.getFileTree(projectPath, config, List(PUG_SUFFIX)).nonEmpty
@@ -40,9 +41,7 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installPugPlugins()) {
-      val pug = Paths.get(projectPath.toString, "node_modules", ".bin", "pug").toString
-      val command =
-        s"${ExternalCommand.toOSCommand(pug)} --client --no-debug --out $tmpTranspileDir ."
+      val command = s"${ExternalCommand.toOSCommand(pug)} --client --no-debug --out $tmpTranspileDir ."
       logger.debug(s"\t+ transpiling Pug templates in $projectPath to $tmpTranspileDir")
       ExternalCommand.run(command, projectPath.toString) match {
         case Success(_) =>

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -5,7 +5,6 @@ import better.files.File.LinkOptions
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.shiftleft.js2cpg.core.Config
-import io.shiftleft.js2cpg.io.ExternalCommand
 import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.io.FileDefaults._
 import io.shiftleft.js2cpg.io.FileUtils
@@ -172,7 +171,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
         val errorMsg =
           s"""npm is not available in your environment. Please install npm and node.js.
             |Also please check if it is set correctly in your systems PATH variable.
-            |Your PATH is: '${ExternalCommand.ENV_PATH_CONTENT}'
+            |Your PATH is: '${TranspilingEnvironment.ENV_PATH_CONTENT}'
             |""".stripMargin
         logger.error(errorMsg)
         System.exit(1)

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -9,6 +9,9 @@ import java.nio.file.Path
 import scala.util.{Failure, Success}
 
 object TranspilingEnvironment {
+
+  val ENV_PATH_CONTENT: String = scala.util.Properties.envOrElse("PATH", "")
+
   // These are singleton objects because we want to check the environment only once
   // even if multiple transpilers require this specific environment:
   private var isValid: Option[Boolean]         = None

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -33,6 +33,8 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private lazy val NODE_OPTIONS: Map[String, String] = nodeOptions()
 
+  private val vue = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
+
   override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
@@ -78,9 +80,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installVuePlugins()) {
       createCustomBrowserslistFile()
-      val vue = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
-      val command =
-        s"${ExternalCommand.toOSCommand(vue)} build --dest $tmpTranspileDir --mode development --no-clean"
+      val command = s"${ExternalCommand.toOSCommand(vue)} build --dest $tmpTranspileDir --mode development --no-clean"
       logger.debug(s"\t+ Vue.js transpiling $projectPath to $tmpTranspileDir")
       ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {
         case Success(_)         => logger.debug("\t+ Vue.js transpiling finished")

--- a/src/test/scala/io/shiftleft/js2cpg/calllinker/CallLinkerPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/calllinker/CallLinkerPassTest.scala
@@ -1,53 +1,31 @@
 package io.shiftleft.js2cpg.calllinker
 
-import better.files.File
-import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
-import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
-import io.shiftleft.js2cpg.core.Js2CpgMain
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.js2cpg.dataflow.DataFlowCode2CpgSuite
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.NoResolve
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.Inside
-import overflowdb._
 
-class CallLinkerPassTest extends AnyWordSpec with Matchers with Inside {
+class CallLinkerPassTest extends DataFlowCode2CpgSuite with Inside {
 
   "CallLinkerPass" should {
+    val cpg: Cpg = code("""
+        |function sayhi() {
+        |  console.log("Hello World!");
+        |}
+        |
+        |sayhi();
+        |""".stripMargin)
 
     "create call edges correctly" in {
-      File.usingTemporaryDirectory() { tmpDir =>
-        val testFile = (tmpDir / "test.js").createFile()
-        testFile.writeText("""
-            |function sayhi() {
-            |    console.log("Hello World!");
-            |}
-            |
-            |sayhi();
-            |""".stripMargin)
-
-        val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
-        Js2CpgMain.main(Array(tmpDir.pathAsString, "--output", cpgPath, "--no-babel"))
-
-        val cpg =
-          CpgLoader
-            .loadFromOverflowDb(
-              CpgLoaderConfig.withDefaults
-                .withOverflowConfig(Config.withDefaults.withStorageLocation(cpgPath))
-            )
-
-        inside(cpg.method("sayhi").l) { case List(m) =>
-          m.name shouldBe "sayhi"
-          m.fullName should endWith(".js::program:sayhi")
-        }
-
-        inside(cpg.method("sayhi").callIn(NoResolve).l) { case List(call) =>
-          call.code shouldBe "sayhi()"
-        }
-
+      inside(cpg.method("sayhi").l) { case List(m) =>
+        m.name shouldBe "sayhi"
+        m.fullName should endWith(".js::program:sayhi")
+      }
+      inside(cpg.method("sayhi").callIn(NoResolve).l) { case List(call) =>
+        call.code shouldBe "sayhi()"
       }
     }
-
   }
 
 }

--- a/src/test/scala/io/shiftleft/js2cpg/dataflow/Js2CpgCode2CpgSuite.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/dataflow/Js2CpgCode2CpgSuite.scala
@@ -24,11 +24,7 @@ class Js2CpgFrontend extends LanguageFrontend {
         outputFile = cpgFile.pathAsString
       )
       js2cpg.run(config)
-      cpg = CpgLoader
-        .loadFromOverflowDb(
-          CpgLoaderConfig.withDefaults
-            .withOverflowConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgFile.pathAsString))
-        )
+      cpg = Cpg.withConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgFile.pathAsString))
     }
     cpg
   }

--- a/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
@@ -11,14 +11,14 @@ class FileUtilsTest extends AnyWordSpec with Matchers {
 
   "FileTree" should {
     "skip ignored files when copying" in {
-      File.usingTemporaryDirectory() { sourceDir =>
+      File.usingTemporaryDirectory("js2cpgTest") { sourceDir =>
         (sourceDir / "a.min.js").createFile()
         (sourceDir / "b-min.js").createFile()
         (sourceDir / "c.spec.js").createFile()
         (sourceDir / "d.chunk.js").createFile()
         (sourceDir / ".folder" / "e.js").createIfNotExists(createParents = true)
 
-        File.usingTemporaryDirectory() { targetDir =>
+        File.usingTemporaryDirectory("js2cpgTest") { targetDir =>
           val copiedDir  = FileUtils.copyToDirectory(sourceDir, targetDir, Config())
           val dirContent = FileUtils.getFileTree(copiedDir.path, Config(), List(JS_SUFFIX))
           dirContent shouldBe empty

--- a/src/test/scala/io/shiftleft/js2cpg/io/PrivateModulesTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/PrivateModulesTest.scala
@@ -28,20 +28,17 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
-        val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
-        Js2CpgMain.main(Array(tmpProjectPath.pathAsString, "--output", cpgPath, "--no-babel"))
+        val cpgPath = tmpDir / "cpg.bin.zip"
+        Js2CpgMain.main(Array(tmpProjectPath.pathAsString, "--output", cpgPath.pathAsString, "--no-babel"))
 
-        val cpg =
-          CpgLoader
-            .loadFromOverflowDb(
-              CpgLoaderConfig.withDefaults
-                .withOverflowConfig(Config.withDefaults.withStorageLocation(cpgPath))
-            )
+        val cpg = Cpg.withConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgPath.pathAsString))
 
         fileNames(cpg) should contain allElementsOf Set(
           s"@privateA${java.io.File.separator}a.js",
           s"@privateB${java.io.File.separator}b.js"
         )
+        cpg.close()
+        cpgPath.deleteOnExit()
       }
     }
 
@@ -50,24 +47,19 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
-        val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
+        val cpgPath = tmpDir / "cpg.bin.zip"
         Js2CpgMain.main(
           Array(
             tmpProjectPath.pathAsString,
             "--output",
-            cpgPath,
+            cpgPath.pathAsString,
             "--no-babel",
             "--private-deps-ns",
             "privateC,privateD"
           )
         )
 
-        val cpg =
-          CpgLoader
-            .loadFromOverflowDb(
-              CpgLoaderConfig.withDefaults
-                .withOverflowConfig(Config.withDefaults.withStorageLocation(cpgPath))
-            )
+        val cpg = Cpg.withConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgPath.pathAsString))
 
         fileNames(cpg) should contain allElementsOf Set(
           s"@privateA${java.io.File.separator}a.js",
@@ -75,6 +67,8 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
           s"@privateC${java.io.File.separator}c.js",
           s"privateD${java.io.File.separator}d.js"
         )
+        cpg.close()
+        cpgPath.deleteOnExit()
       }
     }
 
@@ -83,26 +77,23 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
-        val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
+        val cpgPath = tmpDir / "cpg.bin.zip"
         Js2CpgMain.main(
           Array(
             tmpProjectPath.pathAsString,
             "--output",
-            cpgPath,
+            cpgPath.pathAsString,
             "--no-babel",
             "--exclude-regex",
             s".*@privateA${Pattern.quote(java.io.File.separator)}a.js"
           )
         )
 
-        val cpg =
-          CpgLoader
-            .loadFromOverflowDb(
-              CpgLoaderConfig.withDefaults
-                .withOverflowConfig(Config.withDefaults.withStorageLocation(cpgPath))
-            )
+        val cpg = Cpg.withConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgPath.pathAsString))
 
         fileNames(cpg) should contain only s"@privateB${java.io.File.separator}b.js"
+        cpg.close()
+        cpgPath.deleteOnExit()
       }
     }
 
@@ -111,17 +102,14 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
-        val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
-        Js2CpgMain.main(Array(tmpProjectPath.pathAsString, "--output", cpgPath, "--no-babel"))
+        val cpgPath = tmpDir / "cpg.bin.zip"
+        Js2CpgMain.main(Array(tmpProjectPath.pathAsString, "--output", cpgPath.pathAsString, "--no-babel"))
 
-        val cpg =
-          CpgLoader
-            .loadFromOverflowDb(
-              CpgLoaderConfig.withDefaults
-                .withOverflowConfig(Config.withDefaults.withStorageLocation(cpgPath))
-            )
+        val cpg = Cpg.withConfig(overflowdb.Config.withDefaults.withStorageLocation(cpgPath.pathAsString))
 
         fileNames(cpg) should contain only "index.js"
+        cpg.close()
+        cpgPath.deleteOnExit()
       }
     }
 

--- a/src/test/scala/io/shiftleft/js2cpg/io/PrivateModulesTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/PrivateModulesTest.scala
@@ -25,7 +25,7 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
 
     "copy and generate js files correctly for a simple project" in {
       val projectPath = getClass.getResource("/privatemodules").toURI
-      File.usingTemporaryDirectory() { tmpDir =>
+      File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
@@ -47,7 +47,7 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
 
     "copy and generate js files correctly for a simple project with additional private modules" in {
       val projectPath = getClass.getResource("/privatemodules").toURI
-      File.usingTemporaryDirectory() { tmpDir =>
+      File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
@@ -80,7 +80,7 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
 
     "copy and generate js files correctly for a simple project with filter" in {
       val projectPath = getClass.getResource("/privatemodules").toURI
-      File.usingTemporaryDirectory() { tmpDir =>
+      File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString
@@ -108,7 +108,7 @@ class PrivateModulesTest extends AnyWordSpec with Matchers {
 
     "copy and generate js files correctly for a simple project with no private module being references" in {
       val projectPath = getClass.getResource("/ignoreprivatemodules").toURI
-      File.usingTemporaryDirectory() { tmpDir =>
+      File.usingTemporaryDirectory("js2cpgTest") { tmpDir =>
         val tmpProjectPath = File(projectPath).copyToDirectory(tmpDir)
 
         val cpgPath = (tmpDir / "cpg.bin.zip").path.toString


### PR DESCRIPTION
This hopefully gives more information when certain external commands (e.g., babel) fail.

Also in this PR: some test clean-ups