### PR TITLE
Ignore more folders from build process and detect minified files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,8 +102,7 @@ lazy val commonSettings = Seq(
     "io.joern"                  %% "dataflowengineoss" % joernVersion % Test,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.13"     % Test
-  ),
-  Test / fork := true
+  )
 )
 
 lazy val js2cpg = (project in file(".")).settings(

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,8 @@ lazy val commonSettings = Seq(
     "io.joern"                  %% "dataflowengineoss" % joernVersion % Test,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.13"     % Test
-  )
+  ),
+  Test / fork := true
 )
 
 lazy val js2cpg = (project in file(".")).settings(

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -36,12 +36,12 @@ object FileDefaults {
 
   val CONFIG_FILES: List[String] = List(".json", ".config.js", ".conf.js")
 
-  val NUM_LINES_THRESHOLD: Long = 10000
+  val NUM_LINES_THRESHOLD: Int = 10000
+
+  val LINE_LENGTH_THRESHOLD: Int = 10000
 
   val EMSCRIPTEN_START_FUNCS: Regex = "// EMSCRIPTEN_START_FUNCS.*".r
   val EMSCRIPTEN_END_FUNCS: Regex   = "// EMSCRIPTEN_END_FUNCS.*".r
-
-  val BUILD_PATH_REGEX: Regex = ".*(www|dist|build|vendor).*\\.js".r
 
   val IGNORED_FILES_REGEX: Seq[Regex] = List(
     ".*jest\\.config.*".r,
@@ -64,20 +64,22 @@ object FileDefaults {
   val IGNORED_TESTS_REGEX: Seq[Regex] =
     List(".*[.-]spec\\.js".r, ".*[.-]mock\\.js".r, ".*[.-]e2e\\.js".r, ".*[.-]test\\.js".r)
 
-  val IGNORED_FOLDERS_REGEX: Seq[Regex] =
-    List(
-      "__.*__".r,
-      "\\..*".r,
-      "jest-cache".r,
-      "codemods".r,
-      "e2e".r,
-      "e2e-beta".r,
-      "eslint-rules".r,
-      "flow-typed".r,
-      "i18n".r,
-      "vendor".r,
-      (NODE_MODULES_DIR_NAME + ".*").r
-    )
+  val IGNORED_FOLDERS_REGEX: Seq[Regex] = List(
+    "__.*__".r,
+    "\\..*".r,
+    "jest-cache".r,
+    "codemods".r,
+    "e2e".r,
+    "e2e-beta".r,
+    "eslint-rules".r,
+    "flow-typed".r,
+    "i18n".r,
+    "vendor".r,
+    "www".r,
+    "dist".r,
+    "build".r,
+    (NODE_MODULES_DIR_NAME + ".*").r
+  )
 
   val MINIFIED_PATH_REGEX: Regex = ".*([.-]min\\..*js|bundle\\.js)".r
 

--- a/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
@@ -25,13 +25,15 @@ object JsFileChecks {
     )
   }
 
-  def isMinifiedFile(relPath: String, fileStatistics: FileStatistics): Boolean = {
-    MINIFIED_PATH_REGEX.matches(relPath) || fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD
+  def isMinifiedFile(path: String, fileStatistics: FileStatistics): Boolean = {
+    MINIFIED_PATH_REGEX.matches(path) || fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD
   }
 
   def isMinifiedFile(file: Path): Boolean = {
-    val fileStatistics = FileUtils.fileStatistics(IOUtils.readLinesInFile(file))
-    MINIFIED_PATH_REGEX.matches(file.toString) || fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD
+    if (file.toString.endsWith(".js")) {
+      val fileStatistics = FileUtils.fileStatistics(IOUtils.readLinesInFile(file))
+      isMinifiedFile(file.toString, fileStatistics)
+    } else false
   }
 
   def check(relPath: String, lines: Seq[String]): FileStatistics = {

--- a/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/PathFilter.scala
@@ -66,17 +66,21 @@ case class PathFilter(
     val filterResult: FilterResult = path match {
       // default file ignores:
       case Some(filePath)
-          if filterIgnoredFiles && ignores.exists(_.matches(filePath.toString)) &&
+          if filterIgnoredFiles &&
+            ignores.exists(_.matches(filePath.toString)) &&
             !acceptFromNodeModulesFolder(filePath) =>
         Rejected(relFile, "file ignored by default")
       // minified ignores:
       case Some(filePath)
-          if config.ignoreMinified && MINIFIED_PATH_REGEX.matches(filePath.toString) &&
+          if config.ignoreMinified &&
+            JsFileChecks.isMinifiedFile(file) &&
             !acceptFromNodeModulesFolder(filePath) =>
         Rejected(relFile, "minified file")
       // user ignores:
       case Some(filePath) if shouldBeIgnoredByUserConfig(filePath, config) =>
         Rejected(relFile, "by user configuration")
+      case None =>
+        Rejected(relFile, "invalid path")
       case _ => Accepted()
     }
 

--- a/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/io/FileUtilsTest.scala
@@ -19,10 +19,26 @@ class FileUtilsTest extends AnyWordSpec with Matchers {
         (sourceDir / ".folder" / "e.js").createIfNotExists(createParents = true)
 
         File.usingTemporaryDirectory("js2cpgTest") { targetDir =>
-          val copiedDir  = FileUtils.copyToDirectory(sourceDir, targetDir, Config())
-          val dirContent = FileUtils.getFileTree(copiedDir.path, Config(), List(JS_SUFFIX))
+          val config     = Config(srcDir = sourceDir.pathAsString)
+          val copiedDir  = FileUtils.copyToDirectory(sourceDir, targetDir, config)
+          val dirContent = FileUtils.getFileTree(copiedDir.path, config, List(JS_SUFFIX))
           dirContent shouldBe empty
         }
+      }
+    }
+
+    "skip minified files" in {
+      File.usingTemporaryDirectory("js2cpgTest") { sourceDir =>
+        (sourceDir / "a.min.js").createFile()
+        (sourceDir / "a.min.23472420.js").createFile()
+        (sourceDir / "b-min.js").createFile()
+        (sourceDir / "b-min.23472420.js").createFile()
+
+        val config  = Config(srcDir = sourceDir.pathAsString)
+        val minFile = (sourceDir / "something.js").createFile()
+        minFile.write(s"console.log('${"x" * FileDefaults.LINE_LENGTH_THRESHOLD}');")
+        val dirContent = FileUtils.getFileTree(sourceDir.path, config, List(JS_SUFFIX))
+        dirContent shouldBe empty
       }
     }
   }

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -119,7 +119,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
 
           jsFiles.size shouldBe 0
 
-          new TranspilationRunner(tmpDir.path, transpileOutDir.path, core.Config(babelTranspiling = false)).execute()
+          new TranspilationRunner(tmpDir.path, transpileOutDir.path, Config(babelTranspiling = false)).execute()
 
           val transpiledJsFiles = FileUtils
             .getFileTree(transpileOutDir.path, config, List(JS_SUFFIX))


### PR DESCRIPTION
 - ignore www/, dist/, and build/ (we had DEBUG messages before, but now its actually ignored)
 - ignore files with at least 1 line longer than 10000 characters (as these are most likely minified files)

This is for ShiftLeftSecurity/product#10952