### PR TITLE
Check LOC of minified files

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
@@ -33,7 +33,7 @@ object JsFileChecks {
     case p if MINIFIED_PATH_REGEX.matches(p) => true
     case p if p.endsWith(".js") =>
       val fileStatistics = FileUtils.fileStatistics(IOUtils.readLinesInFile(path))
-      fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD
+      fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD && fileStatistics.linesOfCode <= 50
     case _ => false
   }
 


### PR DESCRIPTION
Babel transpiling sometimes yield files with very long lines. But they are no minified files. We need to check the LOCs additionally.