### PR TITLE
Set commonjs as the default for module mode when TS transpiling

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/parser/JavaScriptParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JavaScriptParser.scala
@@ -12,9 +12,9 @@ object JavaScriptParser {
 
   private val logger = LoggerFactory.getLogger(JavaScriptParser.getClass)
 
-  // 11 is internally used by graaljs for the ECMA script version 2020.
+  // A value >= 13 is internally used by graaljs for the ECMA script version 2022.
   // Sadly the do not provide a define for this.
-  private val ecmaVersion2020 = 11
+  private val ecmaVersion = 13
 
   private val moduleName = ":program"
 
@@ -70,7 +70,7 @@ object JavaScriptParser {
   }
 
   private def buildParser(jsSource: JsSource, errorManager: Js2CpgErrMgr): Parser = {
-    new Parser(ScriptEnvironment.builder().ecmaScriptVersion(ecmaVersion2020).build(), jsSource.source, errorManager)
+    new Parser(ScriptEnvironment.builder().ecmaScriptVersion(ecmaVersion).build(), jsSource.source, errorManager)
   }
 
   private def nodeJsFix(jsSource: JsSource): JsSource = {

--- a/src/main/scala/io/shiftleft/js2cpg/parser/TsConfigJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/TsConfigJsonParser.scala
@@ -2,7 +2,6 @@ package io.shiftleft.js2cpg.parser
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.shiftleft.js2cpg.io.ExternalCommand
-import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler._
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
@@ -12,26 +11,6 @@ import scala.jdk.CollectionConverters._
 object TsConfigJsonParser {
 
   private val logger = LoggerFactory.getLogger(TsConfigJsonParser.getClass)
-
-  def module(projectPath: Path, tsc: String): String = {
-    ExternalCommand.run(s"${ExternalCommand.toOSCommand(tsc)} --showConfig", projectPath.toString) match {
-      case Success(tsConfig) =>
-        val json = new ObjectMapper().readTree(tsConfig)
-        val moduleOption =
-          Option(json.get("compilerOptions"))
-            .flatMap(compOption => Option(compOption.get("module")))
-            .map(_.asText())
-        moduleOption match {
-          case Some(module) if module == ESNEXT || module == ES2020 => ESNEXT
-          case _                                                    => DEFAULT_MODULE
-        }
-      case Failure(exception) =>
-        logger.debug(
-          s"\t- TypeScript - acquiring tsconfig.json failed: ${exception.getMessage}. Assuming no tsconfig and proceeding with $DEFAULT_MODULE as default."
-        )
-        DEFAULT_MODULE
-    }
-  }
 
   def isSolutionTsConfig(projectPath: Path, tsc: String): Boolean = {
     // a solution tsconfig is one with 0 files and at least one reference, see https://angular.io/config/solution-tsconfig
@@ -49,13 +28,9 @@ object TsConfigJsonParser {
   def subprojects(projectPath: Path, tsc: String): List[String] = {
     ExternalCommand.run(s"${ExternalCommand.toOSCommand(tsc)} --showConfig", projectPath.toString) match {
       case Success(config) =>
-        val json = new ObjectMapper().readTree(config)
-        val referenceIt =
-          Option(json.get("references")).map(_.elements().asScala).getOrElse(Iterator.empty)
-        referenceIt.flatMap { reference =>
-          Option(reference.get("path")).map(_.asText)
-        }.toList
-
+        val json        = new ObjectMapper().readTree(config)
+        val referenceIt = Option(json.get("references")).map(_.elements().asScala).getOrElse(Iterator.empty)
+        referenceIt.flatMap { reference => Option(reference.get("path")).map(_.asText) }.toList
       case Failure(exception) =>
         logger.debug(s"\t- TypeScript - listing files failed: ${exception.getMessage}. Assuming no solution tsconfig.")
         Nil

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -8,6 +8,7 @@ import io.shiftleft.js2cpg.io.FileDefaults.TS_SUFFIX
 import io.shiftleft.js2cpg.io.{ExternalCommand, FileUtils}
 import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.parser.TsConfigJsonParser
+import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler.DEFAULT_MODULE
 import org.slf4j.LoggerFactory
 import org.apache.commons.io.{FileUtils => CommonsFileUtils}
 
@@ -16,11 +17,7 @@ import scala.util.{Failure, Success, Try}
 
 object TypescriptTranspiler {
 
-  val COMMONJS: String = "commonjs"
-  val ESNEXT: String   = "esnext"
-  val ES2020: String   = "es2020"
-
-  val DEFAULT_MODULE: String = COMMONJS
+  val DEFAULT_MODULE: String = "commonjs"
 
   private val tscTypingWarnings =
     List("error TS", ".d.ts", "The file is in the program because", "Entry point of type library")
@@ -124,11 +121,8 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
           "" :: Nil
         }
 
-        val module = config.moduleMode.getOrElse(TsConfigJsonParser.module(projectPath, tsc))
-        val outDir =
-          subDir
-            .map(s => File(tmpTranspileDir.toString, s.toString))
-            .getOrElse(File(tmpTranspileDir))
+        val module = config.moduleMode.getOrElse(DEFAULT_MODULE)
+        val outDir = subDir.map(s => File(tmpTranspileDir.toString, s.toString)).getOrElse(File(tmpTranspileDir))
 
         for (proj <- projects) {
           val projCommand = if (proj.nonEmpty) {


### PR DESCRIPTION
Also: update parser to ECMA script version 2022 to support the latest constructs (most likely this is required when transpiling to commonjs).