### PR TITLE
slf4j: upgrade, make log4j-slf4j an 'Optional' dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-val cpgVersion   = "1.3.587"
-val joernVersion = "1.1.1406"
+val cpgVersion   = "1.3.591"
+val joernVersion = "1.1.1418"
 
 val gitCommitString = SettingKey[String]("gitSha")
 
@@ -97,8 +97,8 @@ lazy val commonSettings = Seq(
     "com.fasterxml.jackson.core" % "jackson-databind"  % "2.14.1",
     "com.atlassian.sourcemap"    % "sourcemap"         % "2.0.0",
     "commons-io"                 % "commons-io"        % "2.11.0",
-    "org.slf4j"                  % "slf4j-api"         % "1.7.36",
-    "org.apache.logging.log4j"   % "log4j-slf4j-impl"  % "2.18.0"     % Runtime,
+    "org.slf4j"                  % "slf4j-api"         % "2.0.6",
+    "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % "2.19.0"     % Optional,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.15"     % Test
   )


### PR DESCRIPTION
`Optional` means it's non-transitive