### PR TITLE
add log4j-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,8 @@ lazy val commonSettings = Seq(
     "com.atlassian.sourcemap"    % "sourcemap"         % "2.0.0",
     "commons-io"                 % "commons-io"        % "2.11.0",
     "org.slf4j"                  % "slf4j-api"         % "2.0.6",
-    "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % "2.19.0"     % Optional,
+    "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % "2.19.0" % Optional,
+    "org.apache.logging.log4j"   % "log4j-core"        % "2.19.0" % Optional,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.15"     % Test
   )


### PR DESCRIPTION
to get rid of
```
ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...
```