### PR TITLE
Smarter file reading / file statistics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,8 @@ lazy val commonSettings = Seq(
     "com.atlassian.sourcemap"    % "sourcemap"         % "2.0.0",
     "commons-io"                 % "commons-io"        % "2.11.0",
     "org.slf4j"                  % "slf4j-api"         % "2.0.6",
-    "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % "2.19.0" % Optional,
-    "org.apache.logging.log4j"   % "log4j-core"        % "2.19.0" % Optional,
+    "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % "2.19.0"     % Optional,
+    "org.apache.logging.log4j"   % "log4j-core"        % "2.19.0"     % Optional,
     "io.joern"                  %% "x2cpg"             % joernVersion % Test classifier "tests",
     "org.scalatest"             %% "scalatest"         % "3.2.15"     % Test
   )

--- a/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
@@ -4,11 +4,11 @@ import io.shiftleft.js2cpg.io.FileDefaults.VSIX_SUFFIX
 
 import java.io.File
 import java.nio.file.{Path, Paths}
-import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler
+import io.shiftleft.utils.IOUtils
 
-import scala.util.{Try, Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
 
 object Config {
@@ -80,7 +80,7 @@ case class Config(
 
   def withLoadedIgnores(): Config = {
     val slIngoreFilePath = Paths.get(srcDir, Config.SL_IGNORE_FILE)
-    Try(FileUtils.readLinesInFile(slIngoreFilePath)) match {
+    Try(IOUtils.readLinesInFile(slIngoreFilePath)) match {
       case Failure(_) => this
       case Success(lines) =>
         this.copy(ignoredFiles = ignoredFiles ++ lines.map(createPathForIgnore))

--- a/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/JsFileChecks.scala
@@ -32,13 +32,13 @@ object JsFileChecks {
   def isMinifiedFile(path: Path): Boolean = path.toString match {
     case p if MINIFIED_PATH_REGEX.matches(p) => true
     case p if p.endsWith(".js") =>
-      val fileStatistics = FileUtils.fileStatistics(IOUtils.readLinesInFile(path))
+      val fileStatistics = FileUtils.fileStatistics(path)
       fileStatistics.longestLineLength >= LINE_LENGTH_THRESHOLD && fileStatistics.linesOfCode <= 50
     case _ => false
   }
 
   def check(relPath: String, lines: Seq[String]): FileStatistics = {
-    val fileStatistics = FileUtils.fileStatistics(lines)
+    val fileStatistics = FileUtils.fileStatistics(lines.iterator)
     val reasons        = mutable.ArrayBuffer.empty[String]
 
     // check for very large files (many lines):

--- a/src/main/scala/io/shiftleft/js2cpg/parser/FreshJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/FreshJsonParser.scala
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler
+import io.shiftleft.utils.IOUtils
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
@@ -49,7 +50,7 @@ object FreshJsonParser {
     cachedDependencies.getOrElseUpdate(
       freshJsonPath, {
         val deps = Try {
-          val content      = FileUtils.readLinesInFile(freshJsonPath).mkString("\n")
+          val content      = IOUtils.readLinesInFile(freshJsonPath).mkString("\n")
           val objectMapper = new ObjectMapper
           val json         = objectMapper.readTree(content)
 

--- a/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/JsSource.scala
@@ -8,6 +8,7 @@ import com.oracle.js.parser.ir.Node
 import io.shiftleft.js2cpg.io.FileDefaults._
 import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.preprocessing.NuxtTranspiler
+import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang.StringUtils
 import org.slf4j.LoggerFactory
 
@@ -118,7 +119,7 @@ class JsSource(val srcDir: File, val projectDir: Path, val source: Source) {
       logger.debug(s"No source map file available for '$originalFilePath'")
       None
     } else {
-      val sourceMapContent = FileUtils.readLinesInFile(Paths.get(mapFilePath)).mkString("\n")
+      val sourceMapContent = IOUtils.readLinesInFile(Paths.get(mapFilePath)).mkString("\n")
       // We apply a Try here as some source maps are indeed un-parsable by ReadableSourceMap:
       Try(ReadableSourceMapImpl.fromSource(sourceMapContent)) match {
         case Failure(exception) =>

--- a/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
@@ -3,9 +3,9 @@ package io.shiftleft.js2cpg.parser
 import com.fasterxml.jackson.core.JsonParser
 
 import java.nio.file.{Path, Paths}
-import io.shiftleft.js2cpg.io.FileUtils
 import org.slf4j.LoggerFactory
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang.StringUtils
 
 import scala.collection.concurrent.TrieMap
@@ -60,7 +60,7 @@ object PackageJsonParser {
 
   def isValidProjectPackageJson(packageJsonPath: Path): Boolean = {
     if (packageJsonPath.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME)) {
-      val isNotEmpty = Try(FileUtils.readLinesInFile(packageJsonPath)) match {
+      val isNotEmpty = Try(IOUtils.readLinesInFile(packageJsonPath)) match {
         case Success(content) =>
           content.forall(l => StringUtils.isNotBlank(StringUtils.normalizeSpace(l)))
         case Failure(_) => false
@@ -78,7 +78,7 @@ object PackageJsonParser {
         val lockDepsPath = packageJsonPath.resolveSibling(Paths.get(JSON_LOCK_FILENAME))
 
         val lockDeps = Try {
-          val content      = FileUtils.readLinesInFile(lockDepsPath).mkString("\n")
+          val content      = IOUtils.readLinesInFile(lockDepsPath).mkString("\n")
           val objectMapper = new ObjectMapper
           val packageJson  = objectMapper.readTree(content)
 
@@ -98,7 +98,7 @@ object PackageJsonParser {
 
         // lazy val because we only evaluate this in case no package lock file is available.
         lazy val deps = Try {
-          val content      = FileUtils.readLinesInFile(depsPath).mkString("\n")
+          val content      = IOUtils.readLinesInFile(depsPath).mkString("\n")
           val objectMapper = new ObjectMapper
           val packageJson  = objectMapper.readTree(content)
 

--- a/src/main/scala/io/shiftleft/js2cpg/passes/PrivateKeyFilePass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/passes/PrivateKeyFilePass.scala
@@ -2,7 +2,7 @@ package io.shiftleft.js2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.js2cpg.core.Report
-import io.shiftleft.js2cpg.io.FileUtils
+import io.shiftleft.utils.IOUtils
 
 import java.nio.file.Path
 import scala.util.matching.Regex
@@ -12,10 +12,9 @@ class PrivateKeyFilePass(filenames: List[(Path, Path)], cpg: Cpg, report: Report
 
   private val PRIVATE_KEY: Regex = """.*RSA\sPRIVATE\sKEY.*""".r
 
-  override def fileContent(filePath: Path): Iterable[String] =
-    Iterable("Content omitted for security reasons.")
+  override def fileContent(filePath: Path): Seq[String] = Seq("Content omitted for security reasons.")
 
   override def generateParts(): Array[(Path, Path)] =
-    super.generateParts().filter(p => FileUtils.readLinesInFile(p._1).exists(PRIVATE_KEY.matches))
+    super.generateParts().filter(p => IOUtils.readLinesInFile(p._1).exists(PRIVATE_KEY.matches))
 
 }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -10,6 +10,7 @@ import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.io.FileDefaults._
 import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.parser.PackageJsonParser
+import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, StandardCopyOption}
@@ -55,7 +56,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
 
   private def extractNpmRcModules(npmrc: File): Seq[String] = {
     if (npmrc.exists) {
-      val npmrcContent = FileUtils.readLinesInFile(npmrc.path)
+      val npmrcContent = IOUtils.readLinesInFile(npmrc.path)
       npmrcContent.collect {
         case line if line.contains(FileDefaults.REGISTRY_MARKER) =>
           line.substring(0, line.indexOf(FileDefaults.REGISTRY_MARKER))
@@ -124,7 +125,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
         .foreach(file => file.renameTo(file.pathAsString + ".bak"))
 
       // create a temporary package.json without dependencies
-      val originalContent = FileUtils.readLinesInFile(packageJson.path).mkString("\n")
+      val originalContent = IOUtils.readLinesInFile(packageJson.path).mkString("\n")
       val mapper          = new ObjectMapper()
       val json            = mapper.readTree(PackageJsonParser.removeComments(originalContent))
       val jsonObject      = json.asInstanceOf[ObjectNode]

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -10,6 +10,7 @@ import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.parser.TsConfigJsonParser
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler.DEFAULT_MODULE
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler.DENO_CONFIG
+import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import org.apache.commons.io.{FileUtils => CommonsFileUtils}
 
@@ -73,7 +74,7 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
   private def createCustomTsConfigFile(): Try[File] = {
     val customTsConfigFilePath = (File(projectPath) / "tsconfig.json").path
     Try {
-      val content = FileUtils.readLinesInFile(customTsConfigFilePath).mkString("\n")
+      val content = IOUtils.readLinesInFile(customTsConfigFilePath).mkString("\n")
       val mapper  = new ObjectMapper()
       val json    = mapper.readTree(PackageJsonParser.removeComments(content))
       Option(json.get("compilerOptions")).foreach { options =>


### PR DESCRIPTION
When calculating file statistics we now do not read all lines from the file to a Seq every time. An Iterator is much faster here as we do not want to hold the whole file in memory.