### PR TITLE
Removed CI mode

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -91,8 +91,6 @@ class Js2Cpg {
     }
   }
 
-  private def isInCi: Boolean = sys.env.get("CI").contains("true")
-
   private def collectJsFiles(jsFiles: List[(Path, Path)], dir: Path, config: Config): List[(Path, Path)] = {
     val transpiledJsFiles = FileUtils
       .getFileTree(dir, config, List(JS_SUFFIX, MJS_SUFFIX))
@@ -164,12 +162,8 @@ class Js2Cpg {
     logger.info(s"Generating CPG from Javascript sources in: '$absoluteProjectPath'")
     logger.debug(s"Configuration:$configWithAbsolutProjectPath")
 
-    if (isInCi) {
-      prepareAndGenerateCpg(project, File(absoluteProjectPath), configWithAbsolutProjectPath)
-    } else {
-      File.usingTemporaryDirectory(project.name) { tmpProjectDir =>
-        prepareAndGenerateCpg(project, tmpProjectDir, configWithAbsolutProjectPath)
-      }
+    File.usingTemporaryDirectory(project.name) { tmpProjectDir =>
+      prepareAndGenerateCpg(project, tmpProjectDir, configWithAbsolutProjectPath)
     }
 
     logger.info("Generation of CPG is complete.")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -152,6 +152,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
       // remove project specific engine restrictions and script hooks
       jsonObject.remove("engines")
       jsonObject.remove("scripts")
+      jsonObject.remove("comments")
 
       packageJson.writeText(mapper.writeValueAsString(json))
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -39,8 +39,12 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
-    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed
-    if (nodeVersion().exists(v => v.startsWith("v17") || v.startsWith("v18") || v.startsWith("v19"))) {
+    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed.
+    // This hack is not required on MacOS.
+    if (
+      !scala.util.Properties.isMac &&
+      nodeVersion().exists(v => v.startsWith("v17") || v.startsWith("v18") || v.startsWith("v19"))
+    ) {
       Map("NODE_OPTIONS" -> "--openssl-legacy-provider")
     } else {
       Map.empty

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -39,9 +39,8 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
-    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed.
-    // It is no longer available in v18 and above.
-    if (nodeVersion().exists(v => v.startsWith("v16") || v.startsWith("v17"))) {
+    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed
+    if (nodeVersion().exists(v => v.startsWith("v17") || v.startsWith("v18") || v.startsWith("v19"))) {
       Map("NODE_OPTIONS" -> "--openssl-legacy-provider")
     } else {
       Map.empty

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -39,8 +39,9 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   override def shouldRun(): Boolean = config.vueTranspiling && isVueProject(config, projectPath)
 
   private def nodeOptions(): Map[String, String] = {
-    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed
-    if (nodeVersion().exists(v => v.startsWith("v17") || v.startsWith("v18") || v.startsWith("v19"))) {
+    // TODO: keep this until https://github.com/webpack/webpack/issues/14532 is fixed.
+    // It is no longer available in v18 and above.
+    if (nodeVersion().exists(v => v.startsWith("v16") || v.startsWith("v17"))) {
       Map("NODE_OPTIONS" -> "--openssl-legacy-provider")
     } else {
       Map.empty


### PR DESCRIPTION
In CI mode (CI env variable is usually set by all CI systems) we did not copy the project to a temporary folder. This was nice back in the days when we always installed all project dependencies (utilization of CI caching) but is not required any more as we only install a small subset of dependencies required for transpilation.
With that, pre-installed projects (where `node_modules/` already exists) are no longer an issue (e.g., https://github.com/ShiftLeftSecurity/product/issues/11426)