### PR TITLE
Relaxing pnpm and yarn checks / logging

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -79,7 +79,7 @@ trait TranspilingEnvironment {
         logger.debug(s"\t+ pnpm is available: $result")
         true
       case Failure(_) =>
-        logger.error("\t- pnpm is not installed. Transpiling sources will not be available.")
+        logger.debug("\t- pnpm is not installed.")
         false
     }
   }
@@ -91,7 +91,7 @@ trait TranspilingEnvironment {
         logger.debug(s"\t+ yarn is available: $result")
         true
       case Failure(_) =>
-        logger.error("\t- yarn is not installed. Transpiling sources will not be available.")
+        logger.debug("\t- yarn is not installed.")
         false
     }
   }


### PR DESCRIPTION
It is not an error if we do not find pnpm or yarn as we will always default back to npm.