### PR TITLE
Handle .npmrc and .yarnrc during transpiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Usage: js2cpg.sh [options] <srcdir>
                            additional private dependencies to be analyzed from 'node_modules/'
   --exclude-html           excludes HTML files (*.html)
   --all-dependencies       install all project dependencies during transpilation (defaults to 'false')
+  --fixed-transpilation-dependencies
+                           install fixed versions of transpilation dependencies during transpilation (defaults to 'true')
 ```
 
 `js2cpg` requires at least one argument `<srcdir>`. `srcdir` is path to the project directory from which you would like to generate a CPG.

--- a/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Config.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.js2cpg.core
 
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.io.FileDefaults.VSIX_SUFFIX
 
 import java.io.File
 import java.nio.file.{Path, Paths}
-import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler
 import io.shiftleft.utils.IOUtils
 
@@ -44,7 +44,7 @@ case class Config(
   vueTranspiling: Boolean = Config.DEFAULT_VUE_TRANSPILING,
   nuxtTranspiling: Boolean = Config.DEFAULT_NUXT_TRANSPILING,
   templateTranspiling: Boolean = Config.DEFAULT_TEMPLATE_TRANSPILING,
-  packageJsonLocation: String = PackageJsonParser.PACKAGE_JSON_FILENAME,
+  packageJsonLocation: String = FileDefaults.PACKAGE_JSON_FILENAME,
   outputFile: String = Config.DEFAULT_CPG_OUT_FILE,
   withTsTypes: Boolean = Config.DEFAULT_TS_TYPES,
   ignoredFilesRegex: Regex = Config.DEFAULT_IGNORED_FILES_REGEX,

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
@@ -77,7 +77,7 @@ class Js2cpgArgumentsParser {
       })
     opt[String](PACKAGE_JSON)
       .text(
-        s"path to the projects package.json (path relative to $SRCDIR or absolute path; defaults to '${SRCDIR + java.io.File.separator + PackageJsonParser.PACKAGE_JSON_FILENAME}')"
+        s"path to the projects package.json (path relative to $SRCDIR or absolute path; defaults to '${SRCDIR + java.io.File.separator + FileDefaults.PACKAGE_JSON_FILENAME}')"
       )
       .action((x, c) => c.copy(packageJsonLocation = x))
       .validate(path => {

--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2cpgArgumentsParser.scala
@@ -77,7 +77,7 @@ class Js2cpgArgumentsParser {
       })
     opt[String](PACKAGE_JSON)
       .text(
-        s"path to the projects package.json (path relative to $SRCDIR or absolute path; defaults to '${SRCDIR + java.io.File.separator + FileDefaults.PACKAGE_JSON_FILENAME}')"
+        s"path to the projects package.json (path relative to $SRCDIR or absolute path; defaults to '$SRCDIR${java.io.File.separator}${FileDefaults.PACKAGE_JSON_FILENAME}')"
       )
       .action((x, c) => c.copy(packageJsonLocation = x))
       .validate(path => {

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -4,41 +4,25 @@ import scala.util.matching.Regex
 
 object FileDefaults {
 
-  val NODE_MODULES_DIR_NAME: String = "node_modules"
-
-  val PRIVATE_MODULES_DIR_NAME: String = "sl_private"
-
-  val WEBPACK_PREFIX: String = "webpack://"
-
-  val REGISTRY_MARKER = ":registry="
-
-  val JS_SUFFIX: String = ".js"
-
-  val MJS_SUFFIX: String = ".mjs"
-
-  val VUE_SUFFIX: String = ".vue"
-
-  val HTML_SUFFIX: String = ".html"
-
-  val KEY_SUFFIX: String = ".key"
-
-  val PUG_SUFFIX: String = ".pug"
-
-  val EJS_SUFFIX: String = ".ejs"
-
-  val TS_SUFFIX: String = ".ts"
-
-  val DTS_SUFFIX: String = ".d.ts"
-
-  val VSIX_SUFFIX: String = ".vsix"
-
-  val NPMRC_NAME: String = ".npmrc"
-
-  val CONFIG_FILES: List[String] = List(".json", ".config.js", ".conf.js")
-
-  val NUM_LINES_THRESHOLD: Int = 10000
-
+  val NUM_LINES_THRESHOLD: Int   = 10000
   val LINE_LENGTH_THRESHOLD: Int = 10000
+
+  val NODE_MODULES_DIR_NAME: String    = "node_modules"
+  val PRIVATE_MODULES_DIR_NAME: String = "sl_private"
+  val WEBPACK_PREFIX: String           = "webpack://"
+  val REGISTRY_MARKER                  = ":registry="
+  val JS_SUFFIX: String                = ".js"
+  val MJS_SUFFIX: String               = ".mjs"
+  val VUE_SUFFIX: String               = ".vue"
+  val HTML_SUFFIX: String              = ".html"
+  val KEY_SUFFIX: String               = ".key"
+  val PUG_SUFFIX: String               = ".pug"
+  val EJS_SUFFIX: String               = ".ejs"
+  val TS_SUFFIX: String                = ".ts"
+  val DTS_SUFFIX: String               = ".d.ts"
+  val VSIX_SUFFIX: String              = ".vsix"
+  val NPMRC_NAME: String               = ".npmrc"
+  val YARNRC_NAME: String              = ".yarnrc"
 
   val EMSCRIPTEN_START_FUNCS: Regex = "// EMSCRIPTEN_START_FUNCS.*".r
   val EMSCRIPTEN_END_FUNCS: Regex   = "// EMSCRIPTEN_END_FUNCS.*".r
@@ -86,5 +70,34 @@ object FileDefaults {
   )
 
   val MINIFIED_PATH_REGEX: Regex = ".*([.-]min\\..*js|bundle\\.js)".r
+
+  val PACKAGE_JSON_FILENAME: String  = "package.json"
+  val JSON_LOCK_FILENAME: String     = "package-lock.json"
+  val PNPM_LOCK_FILENAME: String     = "pnpm-lock.yaml"
+  val PNPM_LOCK_FILENAME_BAK: String = "pnpm-lock.yaml.bak"
+  val YARN_LOCK_FILENAME: String     = "yarn.lock"
+  val YARN_LOCK_FILENAME_BAK: String = "yarn.lock.bak"
+
+  private val NPM_SHRINKWRAP_FILENAME: String = "npm-shrinkwrap.json"
+  private val PNPM_WS_FILENAME: String        = "pnpm-workspace.yaml"
+  private val WEBPACK_CONFIG_FILENAME: String = "webpack.config.js"
+  private val ES_LINT_RC_FILENAME: String     = ".eslintrc.js"
+  private val ANGULAR_JSON_FILENAME: String   = "angular.json"
+
+  val PROJECT_CONFIG_FILES: List[String] = List(
+    JSON_LOCK_FILENAME,
+    YARN_LOCK_FILENAME,
+    PNPM_LOCK_FILENAME,
+    // pnpm workspace config file is not required as we manually descent into sub-project:
+    PNPM_WS_FILENAME,
+    NPM_SHRINKWRAP_FILENAME,
+    WEBPACK_CONFIG_FILENAME,
+    ANGULAR_JSON_FILENAME,
+    ES_LINT_RC_FILENAME,
+    NPMRC_NAME,
+    YARNRC_NAME
+  )
+
+  val CONFIG_FILES: List[String] = List(".json", ".config.js", ".conf.js")
 
 }

--- a/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/parser/PackageJsonParser.scala
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonParser
 import java.nio.file.{Path, Paths}
 import org.slf4j.LoggerFactory
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang.StringUtils
 
@@ -16,30 +17,6 @@ import scala.util.Success
 
 object PackageJsonParser {
   private val logger = LoggerFactory.getLogger(PackageJsonParser.getClass)
-
-  val PACKAGE_JSON_FILENAME: String   = "package.json"
-  val JSON_LOCK_FILENAME: String      = "package-lock.json"
-  val NPM_SHRINKWRAP_FILENAME: String = "npm-shrinkwrap.json"
-  val ANGULAR_JSON_FILENAME: String   = "angular.json"
-  val PNPM_WS_FILENAME: String        = "pnpm-workspace.yaml"
-  val PNPM_LOCK_FILENAME: String      = "pnpm-lock.yaml"
-  val PNPM_LOCK_FILENAME_BAK: String  = "pnpm-lock.yaml.bak"
-  val YARN_LOCK_FILENAME: String      = "yarn.lock"
-  val YARN_LOCK_FILENAME_BAK: String  = "yarn.lock.bak"
-  val WEBPACK_CONFIG_FILENAME: String = "webpack.config.js"
-  val ES_LINT_RC_FILENAME: String     = ".eslintrc.js"
-
-  val PROJECT_CONFIG_FILES: List[String] = List(
-    JSON_LOCK_FILENAME,
-    YARN_LOCK_FILENAME,
-    PNPM_LOCK_FILENAME,
-    // pnpm workspace config file is not required as we manually descent into sub-project:
-    PNPM_WS_FILENAME,
-    NPM_SHRINKWRAP_FILENAME,
-    WEBPACK_CONFIG_FILENAME,
-    ANGULAR_JSON_FILENAME,
-    ES_LINT_RC_FILENAME
-  )
 
   val PROJECT_DEPENDENCIES: Seq[String] = Seq(
     "dependencies",
@@ -61,7 +38,7 @@ object PackageJsonParser {
   }
 
   def isValidProjectPackageJson(packageJsonPath: Path): Boolean = {
-    if (packageJsonPath.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME)) {
+    if (packageJsonPath.toString.endsWith(FileDefaults.PACKAGE_JSON_FILENAME)) {
       val isNotEmpty = Try(IOUtils.readLinesInFile(packageJsonPath)) match {
         case Success(content) =>
           content.forall(l => StringUtils.isNotBlank(StringUtils.normalizeSpace(l)))
@@ -77,7 +54,7 @@ object PackageJsonParser {
     cachedDependencies.getOrElseUpdate(
       packageJsonPath, {
         val depsPath     = packageJsonPath
-        val lockDepsPath = packageJsonPath.resolveSibling(Paths.get(JSON_LOCK_FILENAME))
+        val lockDepsPath = packageJsonPath.resolveSibling(Paths.get(FileDefaults.JSON_LOCK_FILENAME))
 
         val lockDeps = Try {
           val content      = IOUtils.readLinesInFile(lockDepsPath).mkString
@@ -109,7 +86,7 @@ object PackageJsonParser {
             deps.get
           } else {
             logger.debug(
-              s"No project dependencies found in $PACKAGE_JSON_FILENAME or $JSON_LOCK_FILENAME at '${depsPath.getParent}'."
+              s"No project dependencies found in ${FileDefaults.PACKAGE_JSON_FILENAME} or ${FileDefaults.JSON_LOCK_FILENAME} at '${depsPath.getParent}'."
             )
             Map.empty
           }

--- a/src/main/scala/io/shiftleft/js2cpg/passes/DependenciesPass.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/passes/DependenciesPass.scala
@@ -3,6 +3,7 @@ package io.shiftleft.js2cpg.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.js2cpg.core.Config
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.parser.{FreshJsonParser, PackageJsonParser}
 import io.shiftleft.passes.CpgPass
@@ -15,7 +16,7 @@ class DependenciesPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
     val packagesJsons =
       (FileUtils
         .getFileTree(Paths.get(config.srcDir), config, List(".json"))
-        .filter(_.toString.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME)) :+
+        .filter(_.toString.endsWith(FileDefaults.PACKAGE_JSON_FILENAME)) :+
         config.createPathForPackageJson()).toSet
     packagesJsons.flatMap(p => PackageJsonParser.dependencies(p)).toMap
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/NuxtTranspiler.scala
@@ -4,6 +4,7 @@ import better.files.File
 import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.io.FileDefaults.JS_SUFFIX
 import io.shiftleft.js2cpg.io.{ExternalCommand, FileUtils}
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.parser.PackageJsonParser
 import org.slf4j.LoggerFactory
 
@@ -44,7 +45,7 @@ class NuxtTranspiler(override val config: Config, override val projectPath: Path
 
   private def isNuxtProject: Boolean =
     PackageJsonParser
-      .dependencies((File(config.srcDir) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
+      .dependencies((File(config.srcDir) / FileDefaults.PACKAGE_JSON_FILENAME).path)
       .contains("nuxt")
 
   override def shouldRun(): Boolean = config.nuxtTranspiling && isNuxtProject

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -119,10 +119,10 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
     DEPS_TO_KEEP.exists(dep.startsWith) && !dep.contains("eslint")
 
   private def withTemporaryPackageJson(workUnit: () => Unit): Unit = {
-    val packageJson = File(projectPath) / PackageJsonParser.PACKAGE_JSON_FILENAME
+    val packageJson = File(projectPath) / FileDefaults.PACKAGE_JSON_FILENAME
     if (config.optimizeDependencies && packageJson.exists) {
       // move config files out of the way
-      PackageJsonParser.PROJECT_CONFIG_FILES
+      FileDefaults.PROJECT_CONFIG_FILES
         .map(File(projectPath, _))
         .filter(_.exists)
         .foreach(file => file.renameTo(file.pathAsString + ".bak"))
@@ -163,13 +163,13 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
       workUnit()
 
       // remove freshly created files from transpiler runs
-      PackageJsonParser.PROJECT_CONFIG_FILES.map(File(projectPath, _)).foreach(_.delete(swallowIOExceptions = true))
+      FileDefaults.PROJECT_CONFIG_FILES.map(File(projectPath, _)).foreach(_.delete(swallowIOExceptions = true))
 
       // restore the original package.json
       packageJson.writeText(originalContent)
 
       // restore config files
-      PackageJsonParser.PROJECT_CONFIG_FILES
+      FileDefaults.PROJECT_CONFIG_FILES
         .map(f => File(projectPath, f + ".bak"))
         .filter(_.exists)
         .foreach(file => file.renameTo(file.pathAsString.stripSuffix(".bak")))

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -2,7 +2,7 @@ package io.shiftleft.js2cpg.preprocessing
 
 import better.files.File
 import io.shiftleft.js2cpg.io.ExternalCommand
-import io.shiftleft.js2cpg.parser.PackageJsonParser
+import io.shiftleft.js2cpg.io.FileDefaults
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
@@ -139,11 +139,11 @@ trait TranspilingEnvironment {
   protected def pnpmAvailable(dir: Path): Boolean = isPnpmAvailable match {
     case Some(value) =>
       val hasLockFile =
-        anyLockFileExists(dir, List(PackageJsonParser.PNPM_LOCK_FILENAME_BAK, PackageJsonParser.PNPM_LOCK_FILENAME))
+        anyLockFileExists(dir, List(FileDefaults.PNPM_LOCK_FILENAME_BAK, FileDefaults.PNPM_LOCK_FILENAME))
       value && hasLockFile
     case None =>
       val hasLockFile =
-        anyLockFileExists(dir, List(PackageJsonParser.PNPM_LOCK_FILENAME_BAK, PackageJsonParser.PNPM_LOCK_FILENAME))
+        anyLockFileExists(dir, List(FileDefaults.PNPM_LOCK_FILENAME_BAK, FileDefaults.PNPM_LOCK_FILENAME))
       isPnpmAvailable = Some(hasLockFile && checkForPnpm())
       isPnpmAvailable.get
   }
@@ -152,10 +152,8 @@ trait TranspilingEnvironment {
     case Some(value) =>
       value
     case None =>
-      val hasLockFile = anyLockFileExists(
-        projectPath,
-        List(PackageJsonParser.YARN_LOCK_FILENAME_BAK, PackageJsonParser.YARN_LOCK_FILENAME)
-      )
+      val hasLockFile =
+        anyLockFileExists(projectPath, List(FileDefaults.YARN_LOCK_FILENAME_BAK, FileDefaults.YARN_LOCK_FILENAME))
       isYarnAvailable = Some(hasLockFile && checkForYarn())
       isYarnAvailable.get
   }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -3,6 +3,7 @@ package io.shiftleft.js2cpg.preprocessing
 import better.files.File
 import io.shiftleft.js2cpg.core.Config
 import io.shiftleft.js2cpg.io.ExternalCommand
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.io.FileDefaults.VUE_SUFFIX
 import io.shiftleft.js2cpg.io.FileUtils
 import io.shiftleft.js2cpg.parser.PackageJsonParser
@@ -19,7 +20,7 @@ object VueTranspiler {
   def isVueProject(config: Config, projectPath: Path): Boolean = {
     val hasVueDep =
       PackageJsonParser
-        .dependencies((File(config.srcDir) / PackageJsonParser.PACKAGE_JSON_FILENAME).path)
+        .dependencies((File(config.srcDir) / FileDefaults.PACKAGE_JSON_FILENAME).path)
         .contains("vue")
     hasVueDep && hasVueFiles(config, projectPath)
   }

--- a/src/test/scala/io/shiftleft/js2cpg/passes/DependenciesPassTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/passes/DependenciesPassTest.scala
@@ -4,6 +4,7 @@ import better.files.File
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.js2cpg.core.{Config, Report}
+import io.shiftleft.js2cpg.io.FileDefaults
 import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.preprocessing.TypescriptTranspiler
 import io.shiftleft.semanticcpg.language._
@@ -14,7 +15,7 @@ class DependenciesPassTest extends AbstractPassTest {
 
     "ignore empty package.json" in {
       File.usingTemporaryDirectory("js2cpgTest") { dir =>
-        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        val json = dir / FileDefaults.PACKAGE_JSON_FILENAME
         json.write("")
         PackageJsonParser.isValidProjectPackageJson(json.path) shouldBe false
       }
@@ -22,7 +23,7 @@ class DependenciesPassTest extends AbstractPassTest {
 
     "ignore package.json without any useful content" in {
       File.usingTemporaryDirectory("js2cpgTest") { dir =>
-        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        val json = dir / FileDefaults.PACKAGE_JSON_FILENAME
         json.write("""
             |{
             |  "name": "something",
@@ -38,7 +39,7 @@ class DependenciesPassTest extends AbstractPassTest {
 
     "ignore package.json without dependencies" in {
       File.usingTemporaryDirectory("js2cpgTest") { dir =>
-        val json = dir / PackageJsonParser.PACKAGE_JSON_FILENAME
+        val json = dir / FileDefaults.PACKAGE_JSON_FILENAME
         json.write("{}")
         PackageJsonParser.isValidProjectPackageJson(json.path) shouldBe false
       }
@@ -74,7 +75,7 @@ class DependenciesPassTest extends AbstractPassTest {
           |  }
           |}
           |""".stripMargin,
-      jsonFilename = PackageJsonParser.JSON_LOCK_FILENAME
+      jsonFilename = FileDefaults.JSON_LOCK_FILENAME
     ) { cpg =>
       val deps = getDependencies(cpg).l
       deps.size shouldBe 2
@@ -188,7 +189,7 @@ class DependenciesPassTest extends AbstractPassTest {
       }
     }
 
-    def apply(code: String, jsonContent: String, jsonFilename: String = PackageJsonParser.PACKAGE_JSON_FILENAME)(
+    def apply(code: String, jsonContent: String, jsonFilename: String = FileDefaults.PACKAGE_JSON_FILENAME)(
       f: Cpg => Unit
     ): Unit = {
       DependencyFixture(code, Iterable((jsonFilename, jsonContent)))(f)


### PR DESCRIPTION
Temporarily rename these two config files as they may contain overrides for the default npm repository (e.g., from private company repos). That can lead to yarn/npm install issues.