### PR TITLE
Another whitespace in paths fix

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -46,8 +46,8 @@ class BabelTranspiler(
       "--no-babelrc " +
       s"--source-root '${in.toString}' " +
       "--source-maps true " + babelPresets + babelPlugins +
-      s"--out-dir $outDir $constructIgnoreDirArgs"
-    logger.debug(s"\t+ Babel transpiling $projectPath to $outDir with command '$command'")
+      s"--out-dir '$outDir' $constructIgnoreDirArgs"
+    logger.debug(s"\t+ Babel transpiling '$projectPath' to '$outDir' with command '$command'")
     ExternalCommand.run(command, in.toString) match {
       case Success(_)         => logger.debug("\t+ Babel transpiling finished")
       case Failure(exception) => logger.debug("\t- Babel transpiling failed", exception)

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/PugTranspiler.scala
@@ -42,8 +42,8 @@ class PugTranspiler(override val config: Config, override val projectPath: Path)
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installPugPlugins()) {
-      val command = s"${ExternalCommand.toOSCommand(pug)} --client --no-debug --out $tmpTranspileDir ."
-      logger.debug(s"\t+ transpiling Pug templates in $projectPath to $tmpTranspileDir")
+      val command = s"${ExternalCommand.toOSCommand(pug)} --client --no-debug --out '$tmpTranspileDir' ."
+      logger.debug(s"\t+ transpiling Pug templates in $projectPath to '$tmpTranspileDir'")
       ExternalCommand.run(command, projectPath.toString) match {
         case Success(_) =>
           logger.debug("\t+ transpiling Pug templates finished")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -158,9 +158,9 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
             else ""
 
           val command =
-            s"${ExternalCommand.toOSCommand(tsc)} --skipLibCheck -sourcemap $sourceRoot --outDir $projOutDir -t ES2017 -m $module --jsx react --noEmit false $projCommand"
+            s"${ExternalCommand.toOSCommand(tsc)} --skipLibCheck -sourcemap $sourceRoot --outDir '$projOutDir' -t ES2017 -m $module --jsx react --noEmit false $projCommand"
           logger.debug(
-            s"\t+ TypeScript compiling $projectPath $projCommand to $projOutDir (using $module style modules)"
+            s"\t+ TypeScript compiling $projectPath $projCommand to '$projOutDir' (using $module style modules)"
           )
 
           ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -86,8 +86,8 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installVuePlugins()) {
       createCustomBrowserslistFile()
-      val command = s"${ExternalCommand.toOSCommand(vue)} build --dest $tmpTranspileDir --mode development --no-clean"
-      logger.debug(s"\t+ Vue.js transpiling $projectPath to $tmpTranspileDir")
+      val command = s"${ExternalCommand.toOSCommand(vue)} build --dest '$tmpTranspileDir' --mode development --no-clean"
+      logger.debug(s"\t+ Vue.js transpiling $projectPath to '$tmpTranspileDir'")
       ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {
         case Success(_)         => logger.debug("\t+ Vue.js transpiling finished")
         case Failure(exception) => logger.debug("\t- Vue.js transpiling failed", exception)

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -49,6 +49,26 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
         }
       }
 
+    "generate js files correctly for a simple Babel project in folder with whitespace" in
+      TranspilationFixture("babel") { tmpDir =>
+        File.usingTemporaryDirectory("js2cpgTest folder") { transpileOutDir =>
+          val config = Config(srcDir = transpileOutDir.pathAsString, tsTranspiling = false)
+
+          new TranspilationRunner(tmpDir.path, transpileOutDir.path, config).execute()
+
+          val transpiledJsFiles = FileUtils
+            .getFileTree(transpileOutDir.path, config, List(JS_SUFFIX))
+            .map(f => (f, transpileOutDir.path))
+
+          val expectedJsFiles = List(((transpileOutDir / "foo.js").path, transpileOutDir.path))
+          transpiledJsFiles should contain theSameElementsAs expectedJsFiles
+
+          transpiledJsFiles
+            .map(f => File(f._1).contentAsString.stripLineEnd)
+            .mkString should endWith("//# sourceMappingURL=foo.js.map")
+        }
+      }
+
     "contain correctly re-mapped code fields in simple Babel project" in
       TranspilationFixture("babel") { tmpDir =>
         val cpgPath = tmpDir / "cpg.bin.zip"


### PR DESCRIPTION
It's not only about the input folder (as https://github.com/ShiftLeftSecurity/js2cpg/pull/266 handled) but also about the output path (when transpiling to a temp folder).

For: https://shiftleftinc.atlassian.net/browse/SEN-727