### PR TITLE
Keep vue sass loader dependency

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunner.scala
@@ -24,7 +24,7 @@ class TranspilationRunner(projectPath: Path, tmpTranspileDir: Path, config: Conf
 
   private val transpilers: Seq[Transpiler] = createTranspilers()
 
-  private val DEPS_TO_KEEP: List[String] = List("@vue", "vue", "nuxt")
+  private val DEPS_TO_KEEP: List[String] = List("@vue", "vue", "nuxt", "sass", "node-sass")
 
   private def createTranspilers(): Seq[Transpiler] = {
     // We always run the following transpilers by default when not stated otherwise in the Config.


### PR DESCRIPTION
When a vue.js project uses sass loading the corresponding dependencies must be kept in place. For: https://shiftleftinc.atlassian.net/browse/SEN-1120