### PR TITLE
More memory for Babel transpilation

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/BabelTranspiler.scala
@@ -48,7 +48,7 @@ class BabelTranspiler(
       "--source-maps true " + babelPresets + babelPlugins +
       s"--out-dir '$outDir' $constructIgnoreDirArgs"
     logger.debug(s"\t+ Babel transpiling '$projectPath' to '$outDir' with command '$command'")
-    ExternalCommand.run(command, in.toString) match {
+    ExternalCommand.run(command, in.toString, extraEnv = NODE_OPTIONS) match {
       case Success(_)         => logger.debug("\t+ Babel transpiling finished")
       case Failure(exception) => logger.debug("\t- Babel transpiling failed", exception)
     }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -6,6 +6,10 @@ import java.nio.file.Path
 
 trait Transpiler extends TranspilingEnvironment {
 
+  protected val NODE_OPTIONS: Map[String, String] = Map(
+    "NODE_OPTIONS" -> s"--max_old_space_size=${TranspilingEnvironment.maxMemoryParameter}"
+  )
+
   protected val DEFAULT_IGNORED_DIRS: List[String] = List(
     "build",
     "dist",

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 
 trait Transpiler extends TranspilingEnvironment {
 
-  protected val NODE_OPTIONS: Map[String, String] = Map("NODE_OPTIONS" -> "--max_old_space_size=8192")
+  protected val NODE_OPTIONS: Map[String, String] = Map("NODE_OPTIONS" -> "--max-old-space-size=8192")
 
   protected val DEFAULT_IGNORED_DIRS: List[String] = List(
     "build",

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/Transpiler.scala
@@ -6,9 +6,7 @@ import java.nio.file.Path
 
 trait Transpiler extends TranspilingEnvironment {
 
-  protected val NODE_OPTIONS: Map[String, String] = Map(
-    "NODE_OPTIONS" -> s"--max_old_space_size=${TranspilingEnvironment.maxMemoryParameter}"
-  )
+  protected val NODE_OPTIONS: Map[String, String] = Map("NODE_OPTIONS" -> "--max_old_space_size=8192")
 
   protected val DEFAULT_IGNORED_DIRS: List[String] = List(
     "build",

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilerGroup.scala
@@ -25,7 +25,7 @@ case class TranspilerGroup(override val config: Config, override val projectPath
     }
     logger.info("Installing project dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing plugins with command '$command' in path '$projectPath'")
-    ExternalCommand.run(command, projectPath.toString) match {
+    ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {
       case Success(_) =>
         logger.info("\t+ Plugins installed")
         true

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -127,7 +127,7 @@ trait TranspilingEnvironment {
     case None =>
       nodeVersion()
       isValid = Some(pnpmAvailable(dir) || yarnAvailable() || npmAvailable())
-      logger.debug(s"\t+ transpilation will run with: '${NODE_OPTIONS.mkString}'")
+      logger.debug(s"\t+ additional node ENV settings: '${NODE_OPTIONS.mkString}'")
       isValid.get
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -12,6 +12,11 @@ object TranspilingEnvironment {
 
   val ENV_PATH_CONTENT: String = scala.util.Properties.envOrElse("PATH", "")
 
+  lazy val maxMemoryParameter: String = {
+    val maxValueInMegabytes = Runtime.getRuntime.maxMemory / 1024 / 1024 - 512
+    maxValueInMegabytes.toString
+  }
+
   // These are singleton objects because we want to check the environment only once
   // even if multiple transpilers require this specific environment:
   private var isValid: Option[Boolean]         = None
@@ -127,6 +132,7 @@ trait TranspilingEnvironment {
     case None =>
       nodeVersion()
       isValid = Some(pnpmAvailable(dir) || yarnAvailable() || npmAvailable())
+      logger.debug(s"\t+ transpilation will run with: '${NODE_OPTIONS.mkString}'")
       isValid.get
   }
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TranspilingEnvironment.scala
@@ -12,11 +12,6 @@ object TranspilingEnvironment {
 
   val ENV_PATH_CONTENT: String = scala.util.Properties.envOrElse("PATH", "")
 
-  lazy val maxMemoryParameter: String = {
-    val maxValueInMegabytes = Runtime.getRuntime.maxMemory / 1024 / 1024 - 512
-    maxValueInMegabytes.toString
-  }
-
   // These are singleton objects because we want to check the environment only once
   // even if multiple transpilers require this specific environment:
   private var isValid: Option[Boolean]         = None

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/TypescriptTranspiler.scala
@@ -33,8 +33,6 @@ class TypescriptTranspiler(override val config: Config, override val projectPath
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private val NODE_OPTIONS: Map[String, String] = Map("NODE_OPTIONS" -> "--max_old_space_size=4096")
-
   private val tsc                  = Paths.get(projectPath.toString, "node_modules", ".bin", "tsc").toString
   private val typescriptAndVersion = Versions.nameAndVersion("typescript")
 

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -32,7 +32,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private lazy val NODE_OPTIONS: Map[String, String] = nodeOptions()
+  private lazy val VUE_NODE_OPTIONS: Map[String, String] = nodeOptions()
 
   private val vue           = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
   private val vueAndVersion = Versions.nameAndVersion("@vue/cli-service-global")
@@ -62,7 +62,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
     }
     logger.info("Installing Vue.js dependencies and plugins. That will take a while.")
     logger.debug(s"\t+ Installing Vue.js plugins with command '$command' in path '$projectPath'")
-    ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {
+    ExternalCommand.run(command, projectPath.toString, extraEnv = VUE_NODE_OPTIONS) match {
       case Success(_) =>
         logger.info("\t+ Vue.js plugins installed")
         true
@@ -88,7 +88,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
       createCustomBrowserslistFile()
       val command = s"${ExternalCommand.toOSCommand(vue)} build --dest '$tmpTranspileDir' --mode development --no-clean"
       logger.debug(s"\t+ Vue.js transpiling $projectPath to '$tmpTranspileDir'")
-      ExternalCommand.run(command, projectPath.toString, extraEnv = NODE_OPTIONS) match {
+      ExternalCommand.run(command, projectPath.toString, extraEnv = VUE_NODE_OPTIONS) match {
         case Success(_)         => logger.debug("\t+ Vue.js transpiling finished")
         case Failure(exception) => logger.debug("\t- Vue.js transpiling failed", exception)
       }

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -32,7 +32,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private lazy val VUE_NODE_OPTIONS: Map[String, String] = nodeOptions()
+  private lazy val VUE_NODE_OPTIONS: Map[String, String] = nodeOptions() ++ NODE_OPTIONS
 
   private val vue           = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
   private val vueAndVersion = Versions.nameAndVersion("@vue/cli-service-global")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -32,7 +32,7 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private lazy val VUE_NODE_OPTIONS: Map[String, String] = nodeOptions() ++ NODE_OPTIONS
+  private lazy val VUE_NODE_OPTIONS: Map[String, String] = nodeOptions()
 
   private val vue           = Paths.get(projectPath.toString, "node_modules", ".bin", "vue-cli-service").toString
   private val vueAndVersion = Versions.nameAndVersion("@vue/cli-service-global")


### PR DESCRIPTION
Set `NODE_OPTIONS=--max-old-space-size=8192` automatically.

For: https://shiftleftinc.atlassian.net/browse/SEN-1133

In case a customer got a machine with less available memory: node would simply swap out and SL would run into the 15 min timeout eventually. Still better than crashing. 