### PR TITLE
Multiple fixes for vue transpilation

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileDefaults.scala
@@ -34,6 +34,7 @@ object FileDefaults {
     ".*babel\\.config\\.js".r,
     ".*chunk-vendors.*\\.js".r, // commonly found in webpack / vue.js projects
     ".*app~.*\\.js".r,          // commonly found in webpack / vue.js projects
+    ".*app-legacy\\.js".r,      // commonly found in webpack / vue.js projects
     ".*\\.chunk\\.js".r,        // see: https://github.com/ShiftLeftSecurity/product/issues/8197
     ".*\\.babelrc.*".r,
     ".*\\.eslint.*".r,

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -11,24 +11,51 @@ import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success}
+import scala.util.Try
 
 object VueTranspiler {
+
+  private val BrowsersListRc: String = ".browserslistrc"
+  private val VueConfigJs: String    = "vue.config.js"
+  private val Vue2Config: String =
+    """
+      |module.exports = {
+      |    configureWebpack: {
+      |        devtool: 'source-map'
+      |    }
+      |}
+      |""".stripMargin
+  private val Vue3Config: String =
+    """
+      |const { defineConfig } = require('@vue/cli-service');
+      |module.exports = defineConfig({
+      |  configureWebpack: {
+      |    devtool: 'source-map',
+      |  }
+      |});
+      |""".stripMargin
 
   private def hasVueFiles(config: Config, projectPath: Path): Boolean =
     FileUtils.getFileTree(projectPath, config, List(VUE_SUFFIX)).nonEmpty
 
   def isVueProject(config: Config, projectPath: Path): Boolean = {
     val hasVueDep =
-      PackageJsonParser
-        .dependencies((File(config.srcDir) / FileDefaults.PACKAGE_JSON_FILENAME).path)
-        .contains("vue")
+      PackageJsonParser.dependencies((File(config.srcDir) / FileDefaults.PACKAGE_JSON_FILENAME).path).contains("vue")
     hasVueDep && hasVueFiles(config, projectPath)
+  }
+
+  private def vueVersion(config: Config): Int = {
+    val versionString =
+      PackageJsonParser.dependencies((File(config.srcDir) / FileDefaults.PACKAGE_JSON_FILENAME).path)("vue")
+    // ignore ~, ^, and more from semver; see: https://stackoverflow.com/a/25861938
+    val c = versionString.collectFirst { case c if Try(c.toString.toInt).isSuccess => c.toString.toInt }
+    c.getOrElse(3) // 3 is the latest version; we default to that
   }
 }
 
 class VueTranspiler(override val config: Config, override val projectPath: Path) extends Transpiler {
 
-  import VueTranspiler.isVueProject
+  import VueTranspiler._
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -69,20 +96,29 @@ class VueTranspiler(override val config: Config, override val projectPath: Path)
   }
 
   private def createCustomBrowserslistFile(): Unit = {
-    val browserslistFile = File(projectPath) / ".browserslistrc"
-    if (browserslistFile.exists) {
-      browserslistFile.delete(swallowIOExceptions = true)
+    val browserslistFile = File(projectPath) / BrowsersListRc
+    browserslistFile.delete(swallowIOExceptions = true)
+    browserslistFile.createFile().deleteOnExit(swallowIOExceptions = true)
+    browserslistFile.writeText("last 2 years")
+  }
+
+  private def createCustomVueConfigFile(): Unit = {
+    val vueConfigJsFile = File(projectPath) / VueConfigJs
+    vueConfigJsFile.delete(swallowIOExceptions = true)
+    vueConfigJsFile.createFile().deleteOnExit(swallowIOExceptions = true)
+    if (vueVersion(config) <= 2) {
+      vueConfigJsFile.writeText(Vue2Config)
+    } else {
+      vueConfigJsFile.writeText(Vue3Config)
     }
-    val customBrowserslistFile = File
-      .newTemporaryFile(".browserslistrc", parent = Some(projectPath))
-      .deleteOnExit(swallowIOExceptions = true)
-    customBrowserslistFile.writeText("last 2 years")
   }
 
   override protected def transpile(tmpTranspileDir: Path): Boolean = {
     if (installVuePlugins()) {
       createCustomBrowserslistFile()
-      val command = s"${ExternalCommand.toOSCommand(vue)} build --dest '$tmpTranspileDir' --mode development --no-clean"
+      createCustomVueConfigFile()
+      val command =
+        s"${ExternalCommand.toOSCommand(vue)} build --dest '$tmpTranspileDir' --mode development --no-clean --modern"
       logger.debug(s"\t+ Vue.js transpiling $projectPath to '$tmpTranspileDir'")
       ExternalCommand.run(command, projectPath.toString, extraEnv = VUE_NODE_OPTIONS) match {
         case Success(_)         => logger.debug("\t+ Vue.js transpiling finished")

--- a/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/preprocessing/VueTranspiler.scala
@@ -20,9 +20,9 @@ object VueTranspiler {
   private val Vue2Config: String =
     """
       |module.exports = {
-      |    configureWebpack: {
-      |        devtool: 'source-map'
-      |    }
+      |  configureWebpack: {
+      |    devtool: 'source-map'
+      |  }
       |}
       |""".stripMargin
   private val Vue3Config: String =

--- a/src/test/resources/vue2/vue.config.js
+++ b/src/test/resources/vue2/vue.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-    configureWebpack: {
-        // See available sourcemaps:
-        // https://webpack.js.org/configuration/devtool/#devtool
-        // and try out different ones
-        devtool: 'source-map'
-    }
-}

--- a/src/test/resources/vue3/vue.config.js
+++ b/src/test/resources/vue3/vue.config.js
@@ -1,7 +1,0 @@
-const { defineConfig } = require('@vue/cli-service');
-module.exports = defineConfig({
-  transpileDependencies: true,
-  configureWebpack: {
-    devtool: 'source-map',
-  }
-});


### PR DESCRIPTION
* fixed browserslist filename
* create custom vue.config.js (always enable sourcemaps, overwrite user-specific settings)
* use --modern vue cli build flag to create ES2015+ code. Transpiled and polyfilled bundles for older ES versions are useless.
* fixed vue transpilation dependencies for mixed TS/Vue.js projects. vue-cli does not support that out of the box if the dependencies are not installed explicitly. 

For: https://shiftleftinc.atlassian.net/browse/SEN-1120


