### PR TITLE
Catch visitFileFailed during project copy process

### DIFF
--- a/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/core/Js2Cpg.scala
@@ -6,7 +6,7 @@ import better.files.File.LinkOptions
 import io.shiftleft.js2cpg.passes._
 import io.shiftleft.js2cpg.io.FileDefaults._
 import io.shiftleft.js2cpg.io.FileUtils
-import io.shiftleft.js2cpg.parser.{FreshJsonParser, PackageJsonParser}
+import io.shiftleft.js2cpg.parser.PackageJsonParser
 import io.shiftleft.js2cpg.preprocessing.NuxtTranspiler
 import io.shiftleft.js2cpg.preprocessing.TranspilationRunner
 import io.shiftleft.js2cpg.utils.MemoryMetrics

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileCollector.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileCollector.scala
@@ -51,8 +51,8 @@ class FileCollector private (pathFilter: PathFilter) extends SimpleFileVisitor[P
 
   override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = {
     exc match {
-      case loop: FileSystemLoopException =>
-        logger.warn(s"Cyclic symbolic link detected for file '$file'", loop)
+      case _: FileSystemLoopException =>
+        logger.warn(s"Cyclic symbolic link detected for file '$file' - ignoring")
       case _ =>
         logger.warn(s"Unable to visit file '$file'", exc)
     }

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileCollector.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileCollector.scala
@@ -52,9 +52,9 @@ class FileCollector private (pathFilter: PathFilter) extends SimpleFileVisitor[P
   override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = {
     exc match {
       case loop: FileSystemLoopException =>
-        logger.debug(s"Cyclic symbolic link detected for file '$file'", loop)
+        logger.warn(s"Cyclic symbolic link detected for file '$file'", loop)
       case _ =>
-        logger.debug(s"Unable to visit file '$file'", exc)
+        logger.warn(s"Unable to visit file '$file'", exc)
     }
     FileVisitResult.CONTINUE
   }

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -110,8 +110,8 @@ object FileUtils {
 
           override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = {
             exc match {
-              case loop: FileSystemLoopException =>
-                logger.warn(s"Cyclic symbolic link detected for file '$file'", loop)
+              case _: FileSystemLoopException =>
+                logger.warn(s"Cyclic symbolic link detected for file '$file' - ignoring")
               case _ =>
                 logger.warn(s"Unable to visit file '$file'", exc)
             }

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -111,9 +111,9 @@ object FileUtils {
           override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = {
             exc match {
               case loop: FileSystemLoopException =>
-                logger.debug(s"Cyclic symbolic link detected for file '$file'", loop)
+                logger.warn(s"Cyclic symbolic link detected for file '$file'", loop)
               case _ =>
-                logger.debug(s"Unable to visit file '$file'", exc)
+                logger.warn(s"Unable to visit file '$file'", exc)
             }
             FileVisitResult.CONTINUE
           }

--- a/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
+++ b/src/main/scala/io/shiftleft/js2cpg/io/FileUtils.scala
@@ -4,7 +4,7 @@ import better.files.File
 
 import java.nio.file.{Files, FileVisitResult, Path, SimpleFileVisitor}
 import io.shiftleft.js2cpg.core.Config
-import io.shiftleft.js2cpg.io.FileDefaults._
+import io.shiftleft.js2cpg.io.FileDefaults.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
@@ -13,6 +13,7 @@ import java.nio.charset.CharsetDecoder
 import java.nio.charset.CodingErrorAction
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.FileSystemLoopException
+import java.nio.file.FileVisitOption
 import scala.collection.concurrent.TrieMap
 import scala.collection.{mutable, SortedMap}
 import scala.io.Codec
@@ -65,7 +66,7 @@ object FileUtils {
     filterIgnoredFiles: Boolean = true
   ): List[Path] = {
     val fileCollector = FileCollector(PathFilter(rootPath, config, filterIgnoredFiles, extensions))
-    Files.walkFileTree(rootPath, fileCollector)
+    Files.walkFileTree(rootPath, java.util.Set.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, fileCollector)
     excludedPaths.addAll(fileCollector.excludedPaths)
     fileCollector.files
   }
@@ -85,6 +86,8 @@ object FileUtils {
     if (from.isDirectory) {
       Files.walkFileTree(
         from.path,
+        java.util.Set.of(FileVisitOption.FOLLOW_LINKS),
+        Integer.MAX_VALUE,
         new SimpleFileVisitor[Path] {
           private def newPath(subPath: Path): Path =
             destination.path.resolve(from.path.relativize(subPath))


### PR DESCRIPTION
During the project copy process (to tmp) visiting files may fail. We catch that and continue now. Old impl would simply swallow the exception and stop the whole copy process leaving an empty/broken input directory.

May help in: https://shiftleftinc.atlassian.net/browse/SEN-2244