### PR TITLE
Fix test due to changes to Babel

### DIFF
--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -142,7 +142,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
               File(f._1).contentAsString
                 .split("\n")
                 .filterNot(_.trim == "\"use strict\";") // latest Babel uses strict checking
-                .head // we ignore the sourcemap reference comment here
+                .head                                   // we ignore the sourcemap reference comment here
                 .mkString
                 .stripLineEnd
             )

--- a/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
+++ b/src/test/scala/io/shiftleft/js2cpg/preprocessing/TranspilationRunnerTest.scala
@@ -141,6 +141,7 @@ class TranspilationRunnerTest extends AnyWordSpec with Matchers {
             jsFilesAfterTranspilation.map(f =>
               File(f._1).contentAsString
                 .split("\n")
+                .filterNot(_.trim == "\"use strict\";") // latest Babel uses strict checking
                 .head // we ignore the sourcemap reference comment here
                 .mkString
                 .stripLineEnd


### PR DESCRIPTION
Latest Babel uses strict checking, we skip that line for that specific test case.